### PR TITLE
nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ resolver = "2"
 [workspace.package]
 authors = ["kellnr.io"]
 edition = "2021"
+name = "kellnr"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,182 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1693787605,
+        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fl": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1695268430,
+        "narHash": "sha256-iR+JGU/+HvVVY2oPfb10umY/udAb04Xu/M3QEGy2iI8=",
+        "owner": "accelbread",
+        "repo": "flakelight",
+        "rev": "b0fd6a391c24e03b2baf2a2cf519e9a980adbcdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "accelbread",
+        "repo": "flakelight",
+        "type": "github"
+      }
+    },
+    "fl-rust": {
+      "inputs": {
+        "crane": "crane",
+        "flakelight": [
+          "fl"
+        ]
+      },
+      "locked": {
+        "lastModified": 1695277816,
+        "narHash": "sha256-TtcEAMqqdh6NtlKf7sMipR2JFxKf9LnjH8PFzwABOVc=",
+        "owner": "accelbread",
+        "repo": "flakelight-rust",
+        "rev": "78ad9b280ac4c28d0ade4fe3c28ace22e2bd0be6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "accelbread",
+        "repo": "flakelight-rust",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693654884,
+        "narHash": "sha256-EqKKEl+IOS8TSjkt+xn1qGpsjnx5/ag33YNQ1+c7OuM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e7f35e03abd06a2faef6684d0de813370e13bda8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1694959747,
+        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fl": "fl",
+        "fl-rust": "fl-rust",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "fl-rust",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "fl-rust",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693707092,
+        "narHash": "sha256-HR1EnynBSPqbt+04/yxxqsG1E3n6uXrOl7SPco/UnYo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "98ccb73e6eefc481da6039ee57ad8818d1ca8d56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  outputs = { fl, fl-rust, ... }: fl ./. {
+    systems = [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+    imports = [
+      fl-rust.flakelightModules.default
+    ];
+    devShell = {
+      packages = pkgs: with pkgs; [
+        bzip2
+        curl
+        nodejs_20
+        openssl
+        pkg-config
+        zlib
+        # TODO: these sys crates don't use system libraries so we can't pin them:
+        # libgit2-sys
+        # libssh2-sys
+        # libnghttp2-sys
+        # libsqlite3-sys
+        # zstd-sys
+      ] ++ lib.optionals stdenv.isDarwin ([
+        libiconv
+      ] ++ (with darwin.apple_sdk.frameworks; [
+        CoreFoundation
+        SystemConfiguration
+      ]));
+    };
+  };
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    fl = {
+      url = "github:accelbread/flakelight";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    fl-rust = {
+      url = "github:accelbread/flakelight-rust";
+      inputs.flakelight.follows = "fl";
+    };
+  };
+}


### PR DESCRIPTION
Here's the start of a nix flake if you're interested in such a thing!

Currently it's useful for `nix develop` only, but I'm able to build and run kellnr on an M1 MacBook as well as an x86_64 Linux machine using this shell.

I'm experimenting with a new [flake builder library](https://github.com/accelbread/flakelight) and I think that's why `nix flake show` and `nix build` fail early. I expect `nix build` to not work because I haven't defined the `npm install` step at all, and I haven't tried any npm things in nix before so who knows how well that works.

Marked as a draft just to see if you're interested. Thanks for open sourcing your work!