### PR TITLE
ci: Enable for `devel` branch.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,11 @@ on:
   push:
    branches:
      - main
-#     - devel
+     - devel
   pull_request:
     branches:
       - main
+      - devel
   release:
     types:
       - published


### PR DESCRIPTION
Assuming you want to stick with having `main` vs `devel`...