### PR TITLE
Add a middleware for Authentication of docs route.

### DIFF
--- a/crates/web_ui/src/lib.rs
+++ b/crates/web_ui/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod error;
-mod session;
+pub mod session;
 pub mod settings;
 pub mod ui;
 pub mod user;


### PR DESCRIPTION
Hi @secana!

This is in relation to issue #93.

## What this PR does
- Adds a middleware `auth_when_required` to `web_ui::session` and sets the `session` module to public.
- Utilizes the middleware `auth_when_required` to protect the `docs/` route that serves documentations.

### What `auth_when_required` does
It checks if a user is logged in when `settings.auth_required` is set to true.
- If the user is logged in, it allows the request to pass through.
- Otherwise, a 401 status code is returned.

With these changes, only logged-in users can access the documentation when `settings.auth_required` is set to `true`.
