### PR TITLE
Fix handling of manual documentation uploads

### DIFF
--- a/crates/docs/src/api.rs
+++ b/crates/docs/src/api.rs
@@ -21,8 +21,7 @@ pub async fn docs_in_queue(State(db): DbState) -> ApiResult<Json<DocQueueRespons
 
 // #[put("/<package>/<version>", data = "<docs>")]
 pub async fn publish_docs(
-    Path(package): Path<OriginalName>,
-    Path(version): Path<Version>,
+    Path((package, version)): Path<(OriginalName, Version)>,
     token: Token,
     State(state): AppState,
     mut docs: DocArchive,

--- a/crates/docs/src/doc_archive.rs
+++ b/crates/docs/src/doc_archive.rs
@@ -33,7 +33,7 @@ impl FromRequest<AppStateData, Body> for DocArchive {
             Err(e) => return Err(ApiError::from(&e.to_string())),
         };
 
-        let max_docs_size = state.settings.docs.max_size / 1_000_000;
+        let max_docs_size = state.settings.docs.max_size * 1_000_000;
         if data_bytes.len() > max_docs_size {
             return Err(ApiError::from(&format!(
                 "Invalid max. length. {}/{} bytes.",

--- a/crates/settings/src/docs.rs
+++ b/crates/settings/src/docs.rs
@@ -8,6 +8,6 @@ pub struct Docs {
 
 impl Default for Docs {
     fn default() -> Self {
-        Self { enabled: false, max_size: 100*1000 }
+        Self { enabled: false, max_size: 100 }
     }
 }


### PR DESCRIPTION
This PR fixes a few bugs observed when attempting to use manual documentation uploads (c.f. https://kellnr.io/documentation#manual-rustdoc). With v5.1.0 I get the following:

```
curl -X PUT -H "Authorization: <filtered>" http://<filtered>:8000/api/v1/docs/mycrate/0.1.0 --upload-file doc.zip
Wrong number of path arguments for `Path`. Expected 1 but got 2. Note that multiple parameters must be extracted with a tuple `Path<(_, _)>` or a struct `Path<YourParams>` 
```

The PR provides the following changes:
1. Updates use of `axum::extract::Path` to be `Path((package, version))` in `publish_docs`, rather than handling each path component as a separate function parameter.
2. Since the maximum size of `Bytes` is limited to 2MB by default (c.f. https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html); I updated it to be set based on the user/default settings via `DefaultBodyLimit`. I assume you want this value to be specified in MB, so I also updated the default and used multiplication rather than division when checking the size in `DocArchive::from_request`.