### PR TITLE
Store crates.io and local registry crates in own dir

### DIFF
--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -36,10 +36,6 @@ pub async fn check_ownership(
     }
 }
 
-pub fn crate_path(bin_path: &std::path::Path, name: &str, version: &str) -> std::path::PathBuf {
-    bin_path.join(format!("{}-{}.crate", name, version))
-}
-
 pub async fn me() -> Redirect {
     Redirect::to("/login")
 }
@@ -127,15 +123,10 @@ pub async fn download(
     State(state): AppState,
     Path((package, version)): Path<(OriginalName, Version)>,
 ) -> Result<Vec<u8>, StatusCode> {
-    let settings = state.settings;
     let db = state.db;
     let cs = state.crate_storage;
 
-    let file_path = crate_path(
-        &settings.bin_path(),
-        &package.to_string(),
-        &version.to_string(),
-    );
+    let file_path = cs.crate_path(&package.to_string(), &version.to_string());
 
     if let Err(e) = db
         .increase_download_counter(&package.to_normalized(), &version)

--- a/crates/storage/src/cached_crate_storage.rs
+++ b/crates/storage/src/cached_crate_storage.rs
@@ -22,9 +22,9 @@ pub struct CachedCrateStorage {
 }
 
 impl CachedCrateStorage {
-    pub async fn new(settings: &Settings) -> Result<Self, anyhow::Error> {
+    pub async fn new(crate_folder: PathBuf, settings: &Settings) -> Result<Self, anyhow::Error> {
         let cs = Self {
-            crate_folder: settings.bin_path(),
+            crate_folder,
             doc_queue_path: settings.doc_queue_path(),
             cache: if settings.registry.cache_size > 0 {
                 Some(Cache::new(settings.registry.cache_size))

--- a/crates/storage/src/cratesio_crate_storage.rs
+++ b/crates/storage/src/cratesio_crate_storage.rs
@@ -6,7 +6,9 @@ pub struct CratesIoCrateStorage(CachedCrateStorage);
 
 impl CratesIoCrateStorage {
     pub async fn new(settings: &Settings) -> Result<Self, anyhow::Error> {
-        Ok(Self(CachedCrateStorage::new(settings).await?))
+        Ok(Self(
+            CachedCrateStorage::new(settings.crates_io_bin_path(), settings).await?,
+        ))
     }
 }
 

--- a/crates/storage/src/kellnr_crate_storage.rs
+++ b/crates/storage/src/kellnr_crate_storage.rs
@@ -6,7 +6,9 @@ pub struct KellnrCrateStorage(CachedCrateStorage);
 
 impl KellnrCrateStorage {
     pub async fn new(settings: &Settings) -> Result<Self, anyhow::Error> {
-        Ok(Self(CachedCrateStorage::new(settings).await?))
+        Ok(Self(
+            CachedCrateStorage::new(settings.bin_path(), settings).await?,
+        ))
     }
 
     pub async fn delete(&self, crate_name: &str, crate_version: &str) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
First steps at fixing https://github.com/kellnr/kellnr/issues/178 by storing the crates.io files in the `cratesio` directory and the private repository files in the `crates` directory. As the function already existed to create the `cratesio` directory I'm assuming this was the intended way for this to work.

Executed the manual test as described in #178. The local crates registry and the crates.io mirror are now correctly separated.

On how to setup the migration I have no idea. Probably best to iterate over all the files in the `crates` directory and see of they match (crate name + hash) an entry in either the crates or cratesio repository.

Work to do:
- [x] Changes need testing
- [ ] Probably some sort of migration is needed, to move all the cached crates in the `crates` directory to the `cratesio` directory.