### PR TITLE
Fix requested module  does not provide an export named errors

### DIFF
--- a/ui/src/components/Dependency.vue
+++ b/ui/src/components/Dependency.vue
@@ -29,7 +29,7 @@ import {onBeforeMount, ref, watch} from "vue";
 import axios from "axios";
 import {store} from "../store/store"
 import {useRoute, useRouter} from "vue-router";
-import {CrateData} from "../types/crate_data";
+import type {CrateData} from "../types/crate_data";
 import {CRATE_DATA, CRATESIO_DATA, CRATESIO_LINK} from "../remote-routes";
 
 const props = defineProps<{

--- a/ui/src/components/Footer.vue
+++ b/ui/src/components/Footer.vue
@@ -8,7 +8,8 @@
 <script setup lang="ts">
 import {onBeforeMount, ref} from "vue";
 import axios from "axios";
-import {defaultVersionInfo, VersionInfo} from "../types/version_info";
+import {defaultVersionInfo} from "../types/version_info";
+import type {VersionInfo} from "../types/version_info";
 import {VERSION} from "../remote-routes";
 
 const versionInfo = ref(defaultVersionInfo())

--- a/ui/src/components/StartupConfig.vue
+++ b/ui/src/components/StartupConfig.vue
@@ -90,7 +90,8 @@
 <script setup lang="ts">
 import { onBeforeMount, ref } from "vue";
 import axios from "axios";
-import { emptySettings, Settings } from "../types/settings";
+import { emptySettings } from "../types/settings";
+import type { Settings } from "../types/settings";
 import StartupConfigItem from "./StartupConfigItem.vue";
 import StartupConfigHeader from "./StartupConfigHeader.vue";
 import { SETTINGS } from "../remote-routes";

--- a/ui/src/views/Crate.vue
+++ b/ui/src/views/Crate.vue
@@ -252,7 +252,8 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import CrateSidebarElement from "../components/CrateSidebarElement.vue";
 import {store} from "../store/store";
-import {CrateData, CrateVersionData, defaultCrateData, defaultCrateVersionData, CrateRegistryDep} from "../types/crate_data";
+import {defaultCrateData, defaultCrateVersionData} from "../types/crate_data";
+import type {CrateData, CrateVersionData, CrateRegistryDep} from "../types/crate_data";
 import {CRATE_DATA, CRATE_DELETE, DOCS_BUILD, kellnr_url} from "../remote-routes";
 import Readme from "../components/Readme.vue";
 

--- a/ui/src/views/Crates.vue
+++ b/ui/src/views/Crates.vue
@@ -40,10 +40,10 @@
 import {onBeforeMount, onMounted, ref} from "vue"
 import axios from "axios"
 import CrateCard from "../components/CrateCard.vue"
-import {CrateOverview} from "../types/crate_overview";
+import type {CrateOverview} from "../types/crate_overview";
 import {CRATES, SEARCH, VERSION} from "../remote-routes";
 import {store} from "../store/store";
-import {useRouter, useRoute} from "vue-router";
+import {useRouter} from "vue-router";
 
 const crates = ref<Array<CrateOverview>>([])
 const emptyCrates = ref(false)

--- a/ui/src/views/DocQueue.vue
+++ b/ui/src/views/DocQueue.vue
@@ -16,9 +16,9 @@
 <script setup lang="ts">
 import axios from "axios"
 import {onMounted, ref} from "vue"
-import {DocQueueItem} from "../types/doc_queue_item"
+import type {DocQueueItem} from "../types/doc_queue_item"
 import DocQueueItemCard from "../components/DocQueueItemCard.vue"
-import {DOCS_QUEUE, kellnr_url} from "../remote-routes";
+import {DOCS_QUEUE} from "../remote-routes";
 
 const queue = ref<Array<DocQueueItem>>()
 const emptyQueue = ref(false)

--- a/ui/src/views/Landing.vue
+++ b/ui/src/views/Landing.vue
@@ -50,7 +50,7 @@ import axios from 'axios';
 import { onBeforeMount, ref } from "vue";
 import { STATISTICS } from '../remote-routes';
 import StatisticsCard from '../components/StatisticsCard.vue';
-import { Statistics } from '../types/statistics';
+import type { Statistics } from '../types/statistics';
 import router from '../router';
 
 const statistics = ref<Statistics>();


### PR DESCRIPTION
When running `npm run dev`, I got the following error, which prevented the App component to be rendered:

![image](https://github.com/kellnr/kellnr/assets/28734986/904951d5-2df5-478a-8222-46c147fefdf3)

The error is also present when running the `npm run build` command, but did not prevent the build to succeed:

```bash
X@Y:~/kellnr/ui$ npm run build
> kellnr@0.1.0 build
> vite build

vite v5.0.12 building for production...
src/components/Footer.vue?vue&type=script&setup=true&lang.ts (18:28) "VersionInfo" is not exported by "src/types/version_info.ts", imported by "src/components/Footer.vue?vue&type=script&setup=true&lang.ts".
src/views/Crates.vue?vue&type=script&setup=true&lang.ts (27:8) "CrateOverview" is not exported by "src/types/crate_overview.ts", imported by "src/views/Crates.vue?vue&type=script&setup=true&lang.ts".
src/components/StartupConfig.vue?vue&type=script&setup=true&lang.ts (32:24) "Settings" is not exported by "src/types/settings.ts", imported by "src/components/StartupConfig.vue?vue&type=script&setup=true&lang.ts".
src/components/Dependency.vue?vue&type=script&setup=true&lang.ts (16:8) "CrateData" is not exported by "src/types/crate_data.ts", imported by "src/components/Dependency.vue?vue&type=script&setup=true&lang.ts".
src/views/Crate.vue?vue&type=script&setup=true&lang.ts (93:8) "CrateData" is not exported by "src/types/crate_data.ts", imported by "src/views/Crate.vue?vue&type=script&setup=true&lang.ts".
src/views/Crate.vue?vue&type=script&setup=true&lang.ts (93:19) "CrateVersionData" is not exported by "src/types/crate_data.ts", imported by "src/views/Crate.vue?vue&type=script&setup=true&lang.ts".
src/views/Crate.vue?vue&type=script&setup=true&lang.ts (93:80) "CrateRegistryDep" is not exported by "src/types/crate_data.ts", imported by "src/views/Crate.vue?vue&type=script&setup=true&lang.ts".
src/views/DocQueue.vue?vue&type=script&setup=true&lang.ts (26:8) "DocQueueItem" is not exported by "src/types/doc_queue_item.ts", imported by "src/views/DocQueue.vue?vue&type=script&setup=true&lang.ts".
src/views/Landing.vue?vue&type=script&setup=true&lang.ts (30:9) "Statistics" is not exported by "src/types/statistics.ts", imported by "src/views/Landing.vue?vue&type=script&setup=true&lang.ts".
✓ 380 modules transformed.
dist/index.html                     0.75 kB │ gzip:   0.46 kB
dist/assets/index-CgrFfLkA.css    243.86 kB │ gzip:  33.06 kB
dist/assets/index-TYvHWXPU.js   2,613.97 kB │ gzip: 926.48 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 2.25s
```

Those errors were easily fixed by changing the import method from:

```ts
import {defaultVersionInfo, VersionInfo} from "../types/version_info";
```

to

```ts
import {defaultVersionInfo} from "../types/version_info";
import type {VersionInfo} from "../types/version_info";
```

as mentionned here https://github.com/vitejs/vite/issues/731

