### PR TITLE
build docs with all features enabled

### DIFF
--- a/crates/docs/src/doc_queue.rs
+++ b/crates/docs/src/doc_queue.rs
@@ -1,6 +1,6 @@
 use crate::compute_doc_url;
 use cargo::{
-    core::Workspace,
+    core::{resolver::CliFeatures, Workspace},
     ops::{self, CompileOptions, DocOptions},
     util::command_prelude::CompileMode,
     CargoResult, Config,
@@ -104,7 +104,10 @@ fn generate_docs(crate_path: impl AsRef<Path>) -> CargoResult<()> {
     let manifest_path = crate_path.as_ref().join("Cargo.toml").canonicalize()?;
     let config = Config::default()?;
     let workspace = Workspace::new(&manifest_path, &config)?;
-    let compile_opts = CompileOptions::new(&config, CompileMode::Doc { deps: false })?;
+    let compile_opts = CompileOptions {
+        cli_features: CliFeatures::new_all(true),
+        ..CompileOptions::new(&config, CompileMode::Doc { deps: false })?
+    };
     let options = DocOptions {
         open_result: false,
         compile_opts,


### PR DESCRIPTION
My docs won't have much content when not built with --all-features.
I think this would be a sensible addition for everyone.