### PR TITLE
Share cache between prefetch tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,6 +3302,7 @@ dependencies = [
  "docs",
  "flume",
  "index",
+ "moka",
  "openssl",
  "registry",
  "settings",

--- a/crates/appstate/src/lib.rs
+++ b/crates/appstate/src/lib.rs
@@ -17,7 +17,7 @@ pub type SettingsState = axum::extract::State<Arc<Settings>>;
 pub type CrateStorageState = axum::extract::State<Arc<KellnrCrateStorage>>;
 pub type CrateIoStorageState = axum::extract::State<Arc<CratesIoCrateStorage>>;
 pub type SigningKeyState = axum::extract::State<Key>;
-pub type CratesIoPrefetchSenderState = axum::extract::State<Arc<Sender<CratesioPrefetchMsg>>>;
+pub type CratesIoPrefetchSenderState = axum::extract::State<Sender<CratesioPrefetchMsg>>;
 
 #[derive(Clone, FromRef)]
 pub struct AppStateData {
@@ -27,7 +27,7 @@ pub struct AppStateData {
     pub settings: Arc<Settings>,
     pub crate_storage: Arc<KellnrCrateStorage>,
     pub cratesio_storage: Arc<CratesIoCrateStorage>,
-    pub cratesio_prefetch_sender: Arc<Sender<CratesioPrefetchMsg>>,
+    pub cratesio_prefetch_sender: Sender<CratesioPrefetchMsg>,
 }
 
 pub async fn test_state() -> AppStateData {
@@ -43,6 +43,6 @@ pub async fn test_state() -> AppStateData {
         settings,
         crate_storage,
         cratesio_storage: crateio_storage,
-        cratesio_prefetch_sender: Arc::new(cratesio_prefetch_sender),
+        cratesio_prefetch_sender,
     }
 }

--- a/crates/common/src/original_name.rs
+++ b/crates/common/src/original_name.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::ops::Deref;
 use thiserror::Error;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone, Hash)]
 pub struct OriginalName(String);
 
 #[derive(Debug, PartialEq, Eq, Error)]

--- a/crates/kellnr/Cargo.toml
+++ b/crates/kellnr/Cargo.toml
@@ -27,6 +27,7 @@ axum-extra.workspace = true
 tower-http.workspace = true
 tokio.workspace = true
 openssl = { version = "*", optional = true } # Not needed directly but for cross-compilation with the vendored-openssl feature
+moka.workspace = true
 
 [features]
 vendored-openssl = ["openssl/vendored"]

--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -58,8 +58,6 @@ async fn main() {
     let cratesio_storage: Arc<CratesIoCrateStorage> = init_cratesio_proxy(&settings).await.into();
     let (cratesio_prefetch_sender, cratesio_prefetch_receiver) =
         flume::unbounded::<CratesioPrefetchMsg>();
-    let cratesio_prefetch_sender = Arc::new(cratesio_prefetch_sender);
-    let cratesio_prefetch_receiver = Arc::new(cratesio_prefetch_receiver);
 
     init_cratesio_prefetch_thread(
         get_connect_string(&settings),
@@ -194,8 +192,8 @@ async fn main() {
 
 async fn init_cratesio_prefetch_thread(
     con_string: ConString,
-    sender: Arc<flume::Sender<CratesioPrefetchMsg>>,
-    recv: Arc<flume::Receiver<CratesioPrefetchMsg>>,
+    sender: flume::Sender<CratesioPrefetchMsg>,
+    recv: flume::Receiver<CratesioPrefetchMsg>,
     num_threads: usize,
 ) {
     // Threads that takes messages to update the crates.io index


### PR DESCRIPTION
Hi, noticed that the cache is not shared between the crates_io prefetch tasks.  And made a draft to changes this, but as it requires moving some settings up to main, I wonder if it would not be better to spawn the tasks in `cratesio_prefetch_api.rs`. Let me know what you think is best and I'll update that.

Als removed the Arc around the flume channels. They already contain an Arc internal, so wrapping them in an Arc is a bit double.