### PR TITLE
feat(token): Add input with copy button to "add token"-notification

### DIFF
--- a/ui/src/components/AuthToken.vue
+++ b/ui/src/components/AuthToken.vue
@@ -1,21 +1,21 @@
 <template>
   <h2 class="k-h2">Authentication Tokens</h2>
-    <template v-for="item in items" :key="item.name">
-      <div class="authToken glass">
-        <span class="tokenName">{{ item.name }}</span>
-        <span class="tag is-danger is-light">
-          <a @click="deleteToken(item.name, item.id)">Delete</a>
-        </span>
-      </div>
-    </template>
+  <template v-for="item in items" :key="item.name">
+    <div class="authToken glass">
+      <span class="tokenName">{{ item.name }}</span>
+      <span class="tag is-danger is-light">
+        <a @click="deleteToken(item.name, item.id)">Delete</a>
+      </span>
+    </div>
+  </template>
   <form>
     <div class="field">
       <div class="control is-expanded has-icons-left">
         <input
-            class="input is-info"
-            v-model="name"
-            placeholder="Descriptive name for the token"
-            type="text"
+          class="input is-info"
+          v-model="name"
+          placeholder="Descriptive name for the token"
+          type="text"
         />
         <span class="icon is-small is-left">
           <i class="fas fa-align-center"></i>
@@ -23,8 +23,12 @@
       </div>
     </div>
 
-    <status-notification :status="addTokenStatus" @update:clear="addTokenStatus = $event">
-      {{ addTokenMsg }}
+    <status-notification
+      :status="addTokenStatus"
+      @update:clear="addTokenStatus = $event"
+    >
+      <span>{{ addTokenMsg }}</span>
+      <copy-input :content="addedToken"></copy-input>
     </status-notification>
 
     <div class="control">
@@ -34,21 +38,23 @@
 </template>
 
 <script setup lang="ts">
-import {onBeforeMount, ref} from 'vue'
+import { onBeforeMount, ref } from "vue";
+import CopyInput from "./CopyInput.vue";
 import StatusNotification from "../components/StatusNotification.vue";
 import axios from "axios";
-import {useRouter} from "vue-router";
-import {ADD_TOKEN, DELETE_TOKEN, LIST_TOKENS} from "../remote-routes";
+import { useRouter } from "vue-router";
+import { ADD_TOKEN, DELETE_TOKEN, LIST_TOKENS } from "../remote-routes";
 
-const addTokenStatus = ref("")
-const addTokenMsg = ref("")
-const items = ref([])
-const name = ref("")
-const router = useRouter()
+const addTokenStatus = ref("");
+const addTokenMsg = ref("");
+const addedToken = ref("");
+const items = ref([]);
+const name = ref("");
+const router = useRouter();
 
 onBeforeMount(() => {
-  getTokens()
-})
+  getTokens();
+});
 
 function addToken() {
   const postData = {
@@ -56,57 +62,56 @@ function addToken() {
   };
 
   axios
-      .post(ADD_TOKEN, postData)
-      .then((res) => {
-        if (res.status == 200) {
-          addTokenMsg.value =
-              'New authentication token: "' +
-              res.data["token"] +
-              '". Copy and save the token as it cannot be displayed again. Do not share the token.';
-          addTokenStatus.value = "Success";
-          // update shown token list
-          getTokens();
+    .post(ADD_TOKEN, postData)
+    .then((res) => {
+      if (res.status == 200) {
+        addedToken.value = res.data["token"];
+        addTokenMsg.value =
+          "New authentication token added. Copy and save the token as it cannot be displayed again. Do not share the token.";
+        addTokenStatus.value = "Success";
+        // update shown token list
+        getTokens();
+      }
+    })
+    .catch((error) => {
+      if (error.response) {
+        addTokenStatus.value = "Error";
+        if (error.response.status == 404) {
+          // "Unauthorized. Login first."
+          router.push("/login");
+        } else if (error.response.status == 500) {
+          addTokenMsg.value = "Token could not be created";
+        } else {
+          addTokenMsg.value = "Unknown error";
         }
-      })
-      .catch((error) => {
-        if (error.response) {
-          addTokenStatus.value = "Error";
-          if (error.response.status == 404) {
-            // "Unauthorized. Login first."
-            router.push("/login");
-          } else if (error.response.status == 500) {
-            addTokenMsg.value = "Token could not be created";
-          } else {
-            addTokenMsg.value = "Unknown error";
-          }
-        }
-      });
+      }
+    });
 }
 
 function getTokens() {
   axios
-      .get(LIST_TOKENS, { cache: false }) // disable caching to get updated token list (TS doesn't recognize cache option)
-      .then((res) => {
-        if (res.status == 200) {
-          items.value = res.data;
-        }
-      })
-      .catch((error) => {
-        console.log(error);
-      });
+    .get(LIST_TOKENS, { cache: false }) // disable caching to get updated token list (TS doesn't recognize cache option)
+    .then((res) => {
+      if (res.status == 200) {
+        items.value = res.data;
+      }
+    })
+    .catch((error) => {
+      console.log(error);
+    });
 }
 
 function deleteToken(name: String, id: number) {
   if (confirm('Delete token "' + name + '"?')) {
     axios
-        .delete(DELETE_TOKEN(id))
-        .then(() => {
-          // Update shown token list
-          getTokens();
-        })
-        .catch((error) => console.log(error));
+      .delete(DELETE_TOKEN(id))
+      .then(() => {
+        // Update shown token list
+        getTokens();
+      })
+      .catch((error) => console.log(error));
   }
-  getTokens()
+  getTokens();
 }
 </script>
 
@@ -122,5 +127,4 @@ function deleteToken(name: String, id: number) {
 .tokenName {
   font-weight: bolder;
 }
-
 </style>

--- a/ui/src/components/CopyInput.vue
+++ b/ui/src/components/CopyInput.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="field has-addons">
+    <div class="control">
+      <input
+        v-model="props.content"
+        ref="input"
+        class="input is-info k-copy-input"
+        type="text"
+        disabled
+      />
+    </div>
+    <div class="control k-hint-container">
+      <button @click.prevent="copyToClipboard" class="button is-info">
+        <span v-if="copyIcon === 'copy'" class="icon">
+          <i class="fa-regular fa-copy"></i>
+        </span>
+        <span v-else-if="copyIcon === 'success'" class="icon">
+          <i class="fa-solid fa-check"></i>
+        </span>
+        <span v-else-if="copyIcon === 'failed'" class="icon">
+          <i class="fa-solid fa-x"></i>
+        </span>
+      </button>
+      <p v-if="copyIcon === 'success'" class="help is-success k-hint">
+        Copied!
+      </p>
+      <p v-else-if="copyIcon === 'failed'" class="help is-danger k-hint">
+        Copy failed!
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+const props = defineProps({ content: { type: String, required: true } });
+
+type CopyIcon = "copy" | "success" | "failed";
+const copyIcon = ref<CopyIcon>("copy");
+
+function copyToClipboard() {
+  const updateIconCb = (copyIconUpdate: CopyIcon, resetTimeout = 2500) => {
+    copyIcon.value = copyIconUpdate;
+    setTimeout(() => {
+      copyIcon.value = "copy";
+    }, resetTimeout);
+  };
+
+  navigator.clipboard
+    .writeText(props.content)
+    .then(() => {
+      updateIconCb("success");
+    })
+    .catch((err) => {
+      updateIconCb("failed");
+      console.error("Failed to copy content to clipboard", err);
+    });
+}
+</script>
+
+<style>
+.k-hint-container {
+  position: relative;
+}
+
+.k-hint {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1050;
+}
+
+.k-copy-input {
+  /* Override the default "forbidden" cursor */
+  cursor: default !important;
+}
+</style>


### PR DESCRIPTION
This PR adds an input with a copy button to the notification message that appears, if a new authentication token is created. This should improve the user experience when the new token needs to be copied as now only one click is required instead of manually selecting the characters by hand.

I decided to use the `navigator.clipboard` api. This is only available in secure context (https and localhost). IMO this is fine as you really shouldn't create an auth token in a non secure environment. [All major browser support this API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard#browser_compatibility). Let me know if browser compatibility with older browsers is a thing.

**Before**
![image](https://github.com/kellnr/kellnr/assets/42588836/1230be04-f458-4728-a2ce-2f4de90bc202)

**After**
![image](https://github.com/kellnr/kellnr/assets/42588836/1ed24c5b-ec17-42a3-9832-2aff4f725480)

----

Thanks for your work! I really enjoy using kellnr :) 

_I hope this PR aligns with your project goals. Otherwise please let me know and I'll be happy to adjust. Furthermore, since I haven't worked with VueJS since a few years and the burma css framework is new to me, don't hesitate to mention any oversight or bad practices._