### PR TITLE
Invalidate cached crate data on delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ just build
 # Build the project (release)
 just build-release
 
-# Test the project (without Docker integration tests)
+# Test the project (without Docker integration tests, requires cargo-nextest)
 just test
 
-# Test the project (with Docker integration tests)
+# Test the project (with Docker integration tests, requires cargo-nextest)
 just test-all
 
 # Run the project

--- a/crates/storage/src/cached_crate_storage.rs
+++ b/crates/storage/src/cached_crate_storage.rs
@@ -110,6 +110,20 @@ impl CachedCrateStorage {
         }
     }
 
+	pub async fn invalidate_path(&self, file_path: &PathBuf) {
+		if let Some(cache) = &self.cache {
+			cache.invalidate(file_path).await;
+		}
+	}
+
+	pub fn cache_has_path(&self, file_path: &PathBuf) -> bool {
+		if let Some(cache) = &self.cache {
+			cache.contains_key(file_path)
+		} else {
+			false
+		}
+	}
+
     pub async fn create_rand_doc_queue_path(&self) -> Result<PathBuf, StorageError> {
         let rand = generate_rand_string(10);
         let dir = self.doc_queue_path.join(rand);

--- a/crates/storage/src/kellnr_crate_storage.rs
+++ b/crates/storage/src/kellnr_crate_storage.rs
@@ -13,9 +13,10 @@ impl KellnrCrateStorage {
 
     pub async fn delete(&self, crate_name: &str, crate_version: &str) -> Result<(), StorageError> {
         let path = self.0.crate_path(crate_name, crate_version);
-        tokio::fs::remove_file(path.clone())
+        tokio::fs::remove_file(&path)
             .await
-            .map_err(|e| StorageError::RemoveFile(path, e))?;
+            .map_err(|e| StorageError::RemoveFile(path.clone(), e))?;
+        self.0.invalidate_path(&path).await;
         Ok(())
     }
 }


### PR DESCRIPTION
Currently, kellnr's cache allows for deleted crate data to be served.

I encountered this issue when publishing a crate version, deleting the version via the UI, publishing the same crate version, and then trying to pull that version down locally.

Trying to pull the crate from kellnr gave checksum errors. I noticed that restarting kellnr after the delete would not give these issues. I tracked down that the cache was holding onto the deleted crate data and had no mechanism to invalidate itself.

This seems to be the underlying issue behind #181, #311, and #348. I'm assuming when they restarted/updated their kellnr instance it resolved the problem, but this PR should prevent it from occurring/resurfacing.

A future feature could be to prune items in the cache after a period of time in case the underlying filesystem data changes and kellnr isn't notified/restarted.