### PR TITLE
Make version, as well as config and static directories configurable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,9 +80,6 @@ jobs:
           echo "KELLNR_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
           echo $KELLNR_VERSION
 
-      - name: Replace Version in web_ui/ui
-        run: sed -i 's/0.0.0-debug/'"$KELLNR_VERSION"'/' crates/web_ui/src/ui.rs
-
       - name: Build Release {{ matrix.target }}
         run: just target=${{ matrix.target }} ci-release
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ nix build
 
 #### Build options
 
-The following environment variables can be set at compile time to tell kellnr where it can find some
-relevant files.
+The following environment variables can be set at compile time:
 
+- `KELLNR_VERSION`: The version of kellnr currently being compiled (default: `0.0.0-unknown`).
 - `KELLNR_CONFIG_DIR`: The configuration directory (default: `./config`, `../config`, or `../../config`).
 - `KELLNR_STATIC_DIR`: The static html directory (default: `./static`).
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ just build
 # Build the project (release)
 just build-release
 
+# Build the frontend (result is placed in ./static)
+just npm-build
+
 # Test the project (without Docker integration tests, requires cargo-nextest)
 just test
 
@@ -93,6 +96,14 @@ nix develop
 # Build the project
 nix build
 ```
+
+#### Build options
+
+The following environment variables can be set at compile time to tell kellnr where it can find some
+relevant files.
+
+- `KELLNR_CONFIG_DIR`: The configuration directory (default: `./config`, `../config`, or `../../config`).
+- `KELLNR_STATIC_DIR`: The static html directory (default: `./static`).
 
 ### Sea ORM & PostgreSQL
 

--- a/crates/db/migration/src/m20220101_000009_create_table.rs
+++ b/crates/db/migration/src/m20220101_000009_create_table.rs
@@ -25,18 +25,24 @@ async fn move_cached_crates(db: &SchemaManagerConnection<'_>) -> Result<(), DbEr
     debug!("Moving cached crates...");
     let settings = get_settings().map_err(|e| DbErr::Custom(e.to_string()))?;
 
-    // Make sure the cratesio bin path exists
-    if !settings.crates_io_bin_path().exists() {
-        std::fs::create_dir_all(settings.crates_io_bin_path())
-            .map_err(|e| DbErr::Custom(e.to_string()))?;
-    }
-
     // Get all cached crate versions
     let cached_indices = cratesio_index::Entity::find()
         .all(db)
         .await?
         .into_iter()
         .collect::<Vec<_>>();
+
+    if cached_indices.is_empty() {
+        // There is nothing to do
+        debug!("No cached crates to move...");
+        return Ok(());
+    }
+
+    // Make sure the cratesio bin path exists
+    if !settings.crates_io_bin_path().exists() {
+        std::fs::create_dir_all(settings.crates_io_bin_path())
+            .map_err(|e| DbErr::Custom(e.to_string()))?;
+    }
 
     // Move each crate to the new location
     for cached_index in cached_indices {

--- a/crates/db/migration/src/m20220101_000009_create_table.rs
+++ b/crates/db/migration/src/m20220101_000009_create_table.rs
@@ -32,14 +32,14 @@ async fn move_cached_crates(db: &SchemaManagerConnection<'_>) -> Result<(), DbEr
     }
 
     // Get all cached crate versions
-    let cached_indicies = cratesio_index::Entity::find()
+    let cached_indices = cratesio_index::Entity::find()
         .all(db)
         .await?
         .into_iter()
         .collect::<Vec<_>>();
 
     // Move each crate to the new location
-    for cached_index in cached_indicies {
+    for cached_index in cached_indices {
         let cached_crate = cached_index
             .find_related(cratesio_crate::Entity)
             .one(db)

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -96,7 +96,9 @@ impl Settings {
 }
 
 pub fn get_settings() -> Result<Settings, ConfigError> {
-    let path = if Path::new("./config").exists() {
+    let path = if let Some(path) = option_env!("KELLNR_CONFIG_DIR") {
+        Path::new(path)
+    } else if Path::new("./config").exists() {
         Path::new("./config")
     } else if Path::new("../config").exists() {
         Path::new("../config")

--- a/crates/web_ui/src/ui.rs
+++ b/crates/web_ui/src/ui.rs
@@ -31,9 +31,9 @@ pub struct KellnrVersion {
 
 pub async fn kellnr_version() -> Json<KellnrVersion> {
     Json(KellnrVersion {
-        // Replaced automatically by the version from the build job,
-        // if a new release is built.
-        version: "0.0.0-debug".to_string(),
+        version: option_env!("KELLNR_VERSION")
+            .unwrap_or("0.0.0-unknown")
+            .to_string(),
     })
 }
 
@@ -909,7 +909,7 @@ mod tests {
         let result_msg = r.into_body().collect().await.unwrap().to_bytes();
         let result_version = serde_json::from_slice::<KellnrVersion>(&result_msg).unwrap();
 
-        assert_eq!("0.0.0-debug", result_version.version);
+        assert_eq!("0.0.0-unknown", result_version.version);
     }
 
     #[tokio::test]


### PR DESCRIPTION
I'm trying to package kellnr [for the AUR](https://aur.archlinux.org/packages/kellnr), but the current model of dumping everything in the working directory will not work for me. I need the option to compile kellnr to use sensible paths (`/etc/kellnr` and `/usr/share/kellnr`) for its accompanying files. [^1]

This pull requests adds the `KELLNR_CONFIG_DIR` and `KELLNR_STATIC_DIR` compile-time environment variables. If these are not set, behaviour is unchanged [^2]

EDIT: Also UI version was apparently introduced by a sed on CI. Let's not do that.

<details>

<summary>Sidenote</summary

Personal opinion: Merging with rebase exists, use it. Merge commits everywhere create spaghetti commit history. Don't get me wrong, merge commits have their place (large merges / complicated merge conflicts). But they shouldn't be used by default for small-scale projects.

Feel free to ignore this part.

</details>

[^1]: Yes symlinks might work, but I didn't even try. This makes a lot more sense imho.

[^2]: Well, technically main now uses `setting::get_settings()` which by default looks up some directories for the config dir. So that changed, but I don't see it being a problem.