### PR TITLE
Add endpoint to get all versions of a crate

### DIFF
--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -949,6 +949,18 @@ impl DbProvider for Database {
             .collect())
     }
 
+    async fn get_crate_versions(&self, crate_name: &NormalizedName) -> DbResult<Vec<Version>> {
+        let u = crate_meta::Entity::find()
+            .join(JoinType::InnerJoin, crate_meta::Relation::Krate.def())
+            .filter(Expr::col((CrateIden::Table, krate::Column::Name)).eq(crate_name.to_string()))
+            .all(&self.db_con)
+            .await?;
+
+        Ok(u.into_iter()
+            .map(|meta| Version::from_unchecked_str(&meta.version))
+            .collect())
+    }
+
     async fn delete_session_token(&self, session_token: &str) -> DbResult<()> {
         if let Some(s) = session::Entity::find()
             .filter(session::Column::Token.eq(session_token))

--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -50,6 +50,7 @@ pub trait DbProvider: Send + Sync {
     async fn get_crate_id(&self, crate_name: &NormalizedName) -> DbResult<Option<i64>>;
     async fn get_crate_owners(&self, crate_name: &NormalizedName) -> DbResult<Vec<User>>;
     async fn get_crate_users(&self, crate_name: &NormalizedName) -> DbResult<Vec<User>>;
+    async fn get_crate_versions(&self, crate_name: &NormalizedName) -> DbResult<Vec<Version>>;
     async fn delete_session_token(&self, session_token: &str) -> DbResult<()>;
     async fn delete_user(&self, user_name: &str) -> DbResult<()>;
     async fn change_pwd(&self, user_name: &str, new_pwd: &str) -> DbResult<()>;
@@ -217,6 +218,10 @@ pub mod mock {
             }
 
             async fn get_crate_users(&self, _crate_name: &NormalizedName) -> DbResult<Vec<User>> {
+                unimplemented!()
+            }
+
+            async fn get_crate_versions(&self, _crate_name: &NormalizedName) -> DbResult<Vec<Version>> {
                 unimplemented!()
             }
 

--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -148,6 +148,10 @@ async fn main() {
             "/:crate_name/crate_users",
             get(kellnr_api::list_crate_users),
         )
+        .route(
+            "/:crate_name/crate_versions",
+            get(kellnr_api::list_crate_versions),
+        )
         .route("/", get(kellnr_api::search))
         .route("/dl/:package/:version/download", get(kellnr_api::download))
         .route(

--- a/crates/registry/src/crate_version.rs
+++ b/crates/registry/src/crate_version.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrateVersion {
+    pub version: String,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrateVersionList {
+    pub versions: Vec<CrateVersion>,
+}
+
+impl From<Vec<CrateVersion>> for CrateVersionList {
+    fn from(versions: Vec<CrateVersion>) -> Self {
+        Self { versions }
+    }
+}

--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -1,9 +1,9 @@
-use crate::crate_user;
 use crate::pub_data::PubData;
 use crate::pub_success::PubDataSuccess;
 use crate::registry_error::RegistryError;
 use crate::search_params::SearchParams;
 use crate::yank_success::YankSuccess;
+use crate::{crate_user, crate_version};
 use anyhow::Result;
 use appstate::AppState;
 use appstate::DbState;
@@ -170,6 +170,24 @@ pub async fn list_crate_users(
         .collect();
 
     Ok(Json(crate_user::CrateUserList::from(users)))
+}
+
+pub async fn list_crate_versions(
+    Path(crate_name): Path<OriginalName>,
+    State(db): DbState,
+) -> ApiResult<Json<crate_version::CrateVersionList>> {
+    let crate_name = crate_name.to_normalized();
+
+    let versions: Vec<crate_version::CrateVersion> = db
+        .get_crate_versions(&crate_name)
+        .await?
+        .into_iter()
+        .map(|v| crate_version::CrateVersion {
+            version: v.to_string(),
+        })
+        .collect();
+
+    Ok(Json(crate_version::CrateVersionList::from(versions)))
 }
 
 pub async fn search(

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod crate_user;
+pub mod crate_version;
 pub mod cratesio_api;
 pub mod kellnr_api;
 pub mod pub_data;


### PR DESCRIPTION
Hey, I added an endpoint, `/api/v1/crates/:crate_name/crate_versions`, that returns all versions of `crate_name`.

My reason for wanting this is that in the CI I want to check if the version of my crate already exists in the registry and only publish if it hasn't already been released.

`cargo search` or `cargo info` only provide information about the latest version, which is sufficient most of the time, but when working on a fix for an older version, getting the latest version is not enough.

Feel free to change this however you want or just tell me what needs to be changed or added.