### PR TITLE
Apply unique indices to db tables

### DIFF
--- a/crates/db/migration/src/lib.rs
+++ b/crates/db/migration/src/lib.rs
@@ -26,6 +26,7 @@ mod m20250227_005754_add_readonly_user;
 mod m20250227_005754_add_readonly_user_entities;
 mod m20250319_191043_add_groups;
 mod m20250319_191043_add_groups_entities;
+mod m20250414_102510_add_unique_indices;
 mod old_index_metadata;
 
 pub struct Migrator;
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20220101_0000011_create_table::Migration),
             Box::new(m20250227_005754_add_readonly_user::Migration),
             Box::new(m20250319_191043_add_groups::Migration),
+            Box::new(m20250414_102510_add_unique_indices::Migration),
         ]
     }
 }

--- a/crates/db/migration/src/m20250414_102510_add_unique_indices.rs
+++ b/crates/db/migration/src/m20250414_102510_add_unique_indices.rs
@@ -1,6 +1,8 @@
 use sea_orm_migration::{prelude::*, schema::*};
 
-use crate::iden::{CrateIndexIden, CrateUserIden, OwnerIden};
+use crate::iden::{
+    CrateGroupIden, CrateIndexIden, CrateMetaIden, CrateUserIden, GroupUserIden, OwnerIden,
+};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -8,51 +10,132 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        let owner_index = Index::create()
-            .name("idx-owner")
-            .table(OwnerIden::Table)
-            .col(OwnerIden::CrateFk)
-            .col(OwnerIden::UserFk)
-            .unique()
-            .to_owned();
-        manager.create_index(owner_index).await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-owner")
+                    .table(OwnerIden::Table)
+                    .col(OwnerIden::CrateFk)
+                    .col(OwnerIden::UserFk)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
 
-        let user_index = Index::create()
-            .name("idx-crate-user")
-            .table(CrateUserIden::Table)
-            .col(CrateUserIden::CrateFk)
-            .col(CrateUserIden::UserFk)
-            .unique()
-            .to_owned();
-        manager.create_index(user_index).await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-crate-user")
+                    .table(CrateUserIden::Table)
+                    .col(CrateUserIden::CrateFk)
+                    .col(CrateUserIden::UserFk)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
 
-        let crate_index = Index::create()
-            .name("idx-crate-index")
-            .table(CrateIndexIden::Table)
-            .col(CrateIndexIden::CrateFk)
-            .col(CrateIndexIden::Vers)
-            .unique()
-            .to_owned();
-        manager.create_index(crate_index).await
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-crate-index")
+                    .table(CrateIndexIden::Table)
+                    .col(CrateIndexIden::CrateFk)
+                    .col(CrateIndexIden::Vers)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-crate-meta")
+                    .table(CrateMetaIden::Table)
+                    .col(CrateMetaIden::CrateFk)
+                    .col(CrateMetaIden::Version)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-group-user")
+                    .table(GroupUserIden::Table)
+                    .col(GroupUserIden::UserFk)
+                    .col(GroupUserIden::GroupFk)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx-crate-group")
+                    .table(CrateGroupIden::Table)
+                    .col(CrateGroupIden::CrateFk)
+                    .col(CrateGroupIden::GroupFk)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        let owner_index = Index::drop()
-            .name("idx-owner")
-            .table(OwnerIden::Table)
-            .to_owned();
-        manager.drop_index(owner_index).await?;
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-owner")
+                    .table(OwnerIden::Table)
+                    .to_owned(),
+            )
+            .await?;
 
-        let user_index = Index::drop()
-            .name("idx-crate-user")
-            .table(OwnerIden::Table)
-            .to_owned();
-        manager.drop_index(user_index).await?;
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-crate-user")
+                    .table(CrateUserIden::Table)
+                    .to_owned(),
+            )
+            .await?;
 
-        let crate_index = Index::drop()
-            .name("idx-crate-index")
-            .table(CrateIndexIden::Table)
-            .to_owned();
-        manager.drop_index(crate_index).await
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-crate-index")
+                    .table(CrateIndexIden::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-crate-meta")
+                    .table(CrateMetaIden::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-group-user")
+                    .table(GroupUserIden::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx-crate-group")
+                    .table(CrateGroupIden::Table)
+                    .to_owned(),
+            )
+            .await
     }
 }

--- a/crates/db/migration/src/m20250414_102510_add_unique_indices.rs
+++ b/crates/db/migration/src/m20250414_102510_add_unique_indices.rs
@@ -1,0 +1,58 @@
+use sea_orm_migration::{prelude::*, schema::*};
+
+use crate::iden::{CrateIndexIden, CrateUserIden, OwnerIden};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let owner_index = Index::create()
+            .name("idx-owner")
+            .table(OwnerIden::Table)
+            .col(OwnerIden::CrateFk)
+            .col(OwnerIden::UserFk)
+            .unique()
+            .to_owned();
+        manager.create_index(owner_index).await?;
+
+        let user_index = Index::create()
+            .name("idx-crate-user")
+            .table(CrateUserIden::Table)
+            .col(CrateUserIden::CrateFk)
+            .col(CrateUserIden::UserFk)
+            .unique()
+            .to_owned();
+        manager.create_index(user_index).await?;
+
+        let crate_index = Index::create()
+            .name("idx-crate-index")
+            .table(CrateIndexIden::Table)
+            .col(CrateIndexIden::CrateFk)
+            .col(CrateIndexIden::Vers)
+            .unique()
+            .to_owned();
+        manager.create_index(crate_index).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let owner_index = Index::drop()
+            .name("idx-owner")
+            .table(OwnerIden::Table)
+            .to_owned();
+        manager.drop_index(owner_index).await?;
+
+        let user_index = Index::drop()
+            .name("idx-crate-user")
+            .table(OwnerIden::Table)
+            .to_owned();
+        manager.drop_index(user_index).await?;
+
+        let crate_index = Index::drop()
+            .name("idx-crate-index")
+            .table(CrateIndexIden::Table)
+            .to_owned();
+        manager.drop_index(crate_index).await
+    }
+}

--- a/crates/db/tests/postgres_test.rs
+++ b/crates/db/tests/postgres_test.rs
@@ -248,52 +248,7 @@ async fn increase_download_counter_works() {
         .test_add_crate(
             "crate1",
             "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "crate1",
-            "admin",
             &Version::try_from("2.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "crate2",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "crate3",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "crate4",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "crate5",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
             &created,
         )
         .await
@@ -491,53 +446,7 @@ async fn get_crate_summaries_works() {
         .test_add_crate(
             "bcrate",
             "admin",
-            &Version::try_from("1.1.0").unwrap(),
-            &created1,
-        )
-        .await
-        .unwrap();
-
-    let crates = test_db.get_crate_summaries().await.unwrap();
-
-    assert_eq!(2, crates.len());
-    assert_eq!("acrate", crates[0].name);
-    assert_eq!("1.2.0", crates[0].max_version);
-    assert_eq!(0, crates[0].total_downloads);
-    assert_eq!("2020-10-08 11:22:12", crates[0].last_updated);
-    let created1 = Utc.with_ymd_and_hms(2020, 10, 7, 13, 18, 00).unwrap();
-    let created2 = Utc.with_ymd_and_hms(2020, 10, 8, 11, 22, 12).unwrap();
-    test_db
-        .test_add_crate(
-            "acrate",
-            "admin",
-            &Version::try_from("1.1.0").unwrap(),
-            &created1,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "bcrate",
-            "admin",
-            &Version::try_from("1.1.0").unwrap(),
-            &created2,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "acrate",
-            "admin",
-            &Version::try_from("1.2.0").unwrap(),
-            &created2,
-        )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate(
-            "bcrate",
-            "admin",
-            &Version::try_from("1.1.0").unwrap(),
+            &Version::try_from("1.1.1").unwrap(),
             &created1,
         )
         .await
@@ -552,7 +461,7 @@ async fn get_crate_summaries_works() {
     assert_eq!("2020-10-08 11:22:12", crates[0].last_updated);
 
     assert_eq!("bcrate", crates[1].name);
-    assert_eq!("1.1.0", crates[1].max_version);
+    assert_eq!("1.1.1", crates[1].max_version);
     assert_eq!(0, crates[1].total_downloads);
     assert_eq!("2020-10-07 13:18:00", crates[1].last_updated);
 }
@@ -703,15 +612,13 @@ async fn is_owner_true() {
         .await
         .unwrap();
 
-    assert!(
-        test_db
-            .is_owner(
-                &NormalizedName::from_unchecked("mycrate".to_string()),
-                "admin"
-            )
-            .await
-            .unwrap()
-    );
+    assert!(test_db
+        .is_owner(
+            &NormalizedName::from_unchecked("mycrate".to_string()),
+            "admin"
+        )
+        .await
+        .unwrap());
 }
 
 #[pg_testcontainer]
@@ -727,15 +634,13 @@ async fn is_owner_false() {
         .await
         .unwrap();
 
-    assert!(
-        !test_db
-            .is_owner(
-                &NormalizedName::from_unchecked("mycrate".to_string()),
-                "user"
-            )
-            .await
-            .unwrap()
-    );
+    assert!(!test_db
+        .is_owner(
+            &NormalizedName::from_unchecked("mycrate".to_string()),
+            "user"
+        )
+        .await
+        .unwrap());
 }
 
 #[pg_testcontainer]
@@ -753,17 +658,15 @@ async fn delete_owner_valid_owner() {
 
     test_db.delete_owner("mycrate", "admin").await.unwrap();
 
-    assert!(
-        test_db
-            .get_crate_owners(&NormalizedName::from_unchecked("mycrate".to_string()))
-            .await
-            .is_ok()
-    );
+    assert!(test_db
+        .get_crate_owners(&NormalizedName::from_unchecked("mycrate".to_string()))
+        .await
+        .is_ok());
 }
 
 #[pg_testcontainer]
 #[tokio::test]
-async fn test_add_crate_duplicate() {
+async fn test_add_crate_duplicate_owner() {
     test_db
         .test_add_crate(
             "mycrate",
@@ -777,7 +680,7 @@ async fn test_add_crate_duplicate() {
         .test_add_crate(
             "mycrate",
             "admin",
-            &Version::try_from("1.0.0").unwrap(),
+            &Version::try_from("1.0.1").unwrap(),
             &Utc::now(),
         )
         .await
@@ -805,6 +708,8 @@ async fn test_add_crate_different_user() {
         .add_crate(&pm, "cksum", &created, "admin")
         .await
         .unwrap();
+
+    let pm = PublishMetadata::minimal("mycrate", "1.0.1");
     test_db
         .add_crate(&pm, "cksum", &created, "user")
         .await
@@ -891,12 +796,10 @@ async fn get_user_from_token_no_token() {
 #[pg_testcontainer]
 #[tokio::test]
 async fn add_auth_token_no_user() {
-    assert!(
-        test_db
-            .add_auth_token("test", "mytoken", "nouser")
-            .await
-            .is_err()
-    );
+    assert!(test_db
+        .add_auth_token("test", "mytoken", "nouser")
+        .await
+        .is_err());
 }
 
 #[pg_testcontainer]
@@ -944,12 +847,10 @@ async fn add_user_duplicate() {
         .await
         .unwrap();
 
-    assert!(
-        test_db
-            .add_user("user", "pwd", "salt", false, false)
-            .await
-            .is_err()
-    )
+    assert!(test_db
+        .add_user("user", "pwd", "salt", false, false)
+        .await
+        .is_err())
 }
 
 #[pg_testcontainer]

--- a/crates/db/tests/postgres_test.rs
+++ b/crates/db/tests/postgres_test.rs
@@ -102,7 +102,7 @@ async fn get_total_downloads_returns_number_of_total_downloads() {
         )
         .await
         .unwrap();
-    let id2 = test_db
+    test_db
         .test_add_crate(
             "crate2",
             "admin",
@@ -112,15 +112,7 @@ async fn get_total_downloads_returns_number_of_total_downloads() {
         .await
         .unwrap();
     test_db
-        .test_add_crate_meta(id1, &Version::try_from("1.0.0").unwrap(), &created, None)
-        .await
-        .unwrap();
-    test_db
         .test_add_crate_meta(id1, &Version::try_from("2.0.0").unwrap(), &created, None)
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate_meta(id2, &Version::try_from("1.0.0").unwrap(), &created, None)
         .await
         .unwrap();
     test_db
@@ -1001,10 +993,6 @@ async fn crate_version_exists_with_existing_version() {
             &Version::try_from("1.0.0").unwrap(),
             &Utc::now(),
         )
-        .await
-        .unwrap();
-    test_db
-        .test_add_crate_meta(id, "1.0.0", &Utc::now(), None)
         .await
         .unwrap();
 

--- a/crates/db/tests/sqlite_test.rs
+++ b/crates/db/tests/sqlite_test.rs
@@ -341,57 +341,7 @@ async fn increase_download_counter_works() {
         .test_add_crate(
             "crate1",
             "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .db
-        .test_add_crate(
-            "crate1",
-            "admin",
             &Version::try_from("2.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .db
-        .test_add_crate(
-            "crate2",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .db
-        .test_add_crate(
-            "crate3",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .db
-        .test_add_crate(
-            "crate4",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
-            &created,
-        )
-        .await
-        .unwrap();
-    test_db
-        .db
-        .test_add_crate(
-            "crate5",
-            "admin",
-            &Version::try_from("1.0.0").unwrap(),
             &created,
         )
         .await
@@ -565,7 +515,7 @@ async fn get_crate_summaries_works() {
         .test_add_crate(
             "bcrate",
             "admin",
-            &Version::try_from("1.1.0").unwrap(),
+            &Version::try_from("1.1.1").unwrap(),
             &created1,
         )
         .await
@@ -580,7 +530,7 @@ async fn get_crate_summaries_works() {
     assert_eq!("2020-10-08 11:22:12", crates[0].last_updated);
 
     assert_eq!("bcrate", crates[1].name);
-    assert_eq!("1.1.0", crates[1].max_version);
+    assert_eq!("1.1.1", crates[1].max_version);
     assert_eq!(0, crates[1].total_downloads);
     assert_eq!("2020-10-07 13:18:00", crates[1].last_updated);
 }
@@ -600,16 +550,14 @@ async fn is_owner_true() {
         .await
         .unwrap();
 
-    assert!(
-        test_db
-            .db
-            .is_owner(
-                &NormalizedName::from_unchecked("mycrate".to_string()),
-                "admin"
-            )
-            .await
-            .unwrap()
-    );
+    assert!(test_db
+        .db
+        .is_owner(
+            &NormalizedName::from_unchecked("mycrate".to_string()),
+            "admin"
+        )
+        .await
+        .unwrap());
 }
 
 #[tokio::test]
@@ -627,16 +575,14 @@ async fn is_owner_false() {
         .await
         .unwrap();
 
-    assert!(
-        !test_db
-            .db
-            .is_owner(
-                &NormalizedName::from_unchecked("mycrate".to_string()),
-                "user"
-            )
-            .await
-            .unwrap()
-    );
+    assert!(!test_db
+        .db
+        .is_owner(
+            &NormalizedName::from_unchecked("mycrate".to_string()),
+            "user"
+        )
+        .await
+        .unwrap());
 }
 
 #[tokio::test]
@@ -655,17 +601,15 @@ async fn delete_owner_valid_owner() {
 
     test_db.db.delete_owner("mycrate", "admin").await.unwrap();
 
-    assert!(
-        test_db
-            .db
-            .get_crate_owners(&NormalizedName::from_unchecked("mycrate".to_string()))
-            .await
-            .is_ok()
-    );
+    assert!(test_db
+        .db
+        .get_crate_owners(&NormalizedName::from_unchecked("mycrate".to_string()))
+        .await
+        .is_ok());
 }
 
 #[tokio::test]
-async fn add_crate_if_not_exists_duplicate() {
+async fn add_crate_if_not_exists_duplicate_owner() {
     let test_db = TestDB::new().await;
 
     test_db
@@ -683,7 +627,7 @@ async fn add_crate_if_not_exists_duplicate() {
         .test_add_crate(
             "mycrate",
             "admin",
-            &Version::try_from("1.0.0").unwrap(),
+            &Version::try_from("1.0.1").unwrap(),
             &Utc::now(),
         )
         .await
@@ -722,7 +666,7 @@ async fn add_crate_different_user() {
         .test_add_crate(
             "mycrate",
             "user",
-            &Version::try_from("1.0.0").unwrap(),
+            &Version::try_from("1.0.1").unwrap(),
             &Utc::now(),
         )
         .await
@@ -819,13 +763,11 @@ async fn get_user_from_token_no_token() {
 async fn add_auth_token_no_user() {
     let test_db = TestDB::new().await;
 
-    assert!(
-        test_db
-            .db
-            .add_auth_token("test", "mytoken", "nouser")
-            .await
-            .is_err()
-    );
+    assert!(test_db
+        .db
+        .add_auth_token("test", "mytoken", "nouser")
+        .await
+        .is_err());
 }
 
 #[tokio::test]
@@ -878,13 +820,11 @@ async fn add_user_duplicate() {
         .await
         .unwrap();
 
-    assert!(
-        test_db
-            .db
-            .add_user("user", "pwd", "salt", false, false)
-            .await
-            .is_err()
-    )
+    assert!(test_db
+        .db
+        .add_user("user", "pwd", "salt", false, false)
+        .await
+        .is_err())
 }
 
 #[tokio::test]
@@ -1004,13 +944,11 @@ async fn get_name_valid_user_and_token() {
 async fn get_session_no_session_in_db() {
     let test_db = TestDB::new().await;
 
-    assert!(
-        test_db
-            .db
-            .validate_session("no_session_token")
-            .await
-            .is_err()
-    );
+    assert!(test_db
+        .db
+        .validate_session("no_session_token")
+        .await
+        .is_err());
 }
 
 #[tokio::test]
@@ -1039,13 +977,11 @@ async fn authenticate_user_valid() {
 async fn authenticate_user_unknown_user() {
     let test_db = TestDB::new().await;
 
-    assert!(
-        test_db
-            .db
-            .authenticate_user("unknown", "123")
-            .await
-            .is_err()
-    );
+    assert!(test_db
+        .db
+        .authenticate_user("unknown", "123")
+        .await
+        .is_err());
 }
 
 #[tokio::test]

--- a/crates/db/tests/sqlite_test.rs
+++ b/crates/db/tests/sqlite_test.rs
@@ -141,7 +141,7 @@ async fn get_total_downloads_returns_number_of_total_downloads() {
         )
         .await
         .unwrap();
-    let id2 = test_db
+    test_db
         .db
         .test_add_crate(
             "crate2",
@@ -153,17 +153,7 @@ async fn get_total_downloads_returns_number_of_total_downloads() {
         .unwrap();
     test_db
         .db
-        .test_add_crate_meta(id1, &Version::try_from("1.0.0").unwrap(), &created, None)
-        .await
-        .unwrap();
-    test_db
-        .db
         .test_add_crate_meta(id1, &Version::try_from("2.0.0").unwrap(), &created, None)
-        .await
-        .unwrap();
-    test_db
-        .db
-        .test_add_crate_meta(id2, &Version::try_from("1.0.0").unwrap(), &created, None)
         .await
         .unwrap();
     test_db


### PR DESCRIPTION
Solves first part of #675 

Adds unique indices to the db tables:

- CrateGroup
- CrateIndex
- CrateMeta
- CrateUser
- GroupUser
- Owner

Updates tests that created duplicate entries, which now would fail.

As I am not that familiar with kellnr's code yet, if you'd think there should be more (or less) tables with guaranteed uniqueness let me know. I will update the PR.