### PR TITLE
style: inline format args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,6 @@ pedantic = { level = "warn", priority = -1 }
 used_underscore_binding = "allow" # 672
 missing_errors_doc = "allow" # 182
 must_use_candidate = "allow" # 74
-uninlined_format_args = "allow" # 52
 default_trait_access = "allow" # 45
 implicit_clone = "allow" # 32
 cast_possible_truncation = "allow" # 28

--- a/crates/auth/src/auth_req_token.rs
+++ b/crates/auth/src/auth_req_token.rs
@@ -22,7 +22,7 @@ pub async fn cargo_auth_when_required(
     match token {
         Ok(_) => Ok(next.run(request).await),
         Err(status) => {
-            warn!("Authentication required, but failed: {}", status);
+            warn!("Authentication required, but failed: {status}");
             Err(status)
         }
     }

--- a/crates/common/src/index_metadata.rs
+++ b/crates/common/src/index_metadata.rs
@@ -182,9 +182,9 @@ impl IndexMetadata {
         let mut index = String::new();
         for (i, ix) in indices.iter().enumerate() {
             if i == indices.len() - 1 {
-                write!(&mut index, "{}", ix).unwrap();
+                write!(&mut index, "{ix}").unwrap();
             } else {
-                writeln!(&mut index, "{}", ix).unwrap();
+                writeln!(&mut index, "{ix}").unwrap();
             }
         }
         Ok(index)
@@ -272,7 +272,7 @@ impl Display for DependencyKind {
             DependencyKind::Normal => write!(f, "normal"),
             DependencyKind::Build => write!(f, "build"),
             DependencyKind::Dev => write!(f, "dev"),
-            DependencyKind::Other(s) => write!(f, "{}", s),
+            DependencyKind::Other(s) => write!(f, "{s}"),
         }
     }
 }

--- a/crates/common/src/normalized_name.rs
+++ b/crates/common/src/normalized_name.rs
@@ -30,7 +30,7 @@ impl From<&OriginalName> for NormalizedName {
 
 impl fmt::Display for NormalizedName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/common/src/original_name.rs
+++ b/crates/common/src/original_name.rs
@@ -79,7 +79,7 @@ impl Deref for OriginalName {
 
 impl fmt::Display for OriginalName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/common/src/version.rs
+++ b/crates/common/src/version.rs
@@ -82,7 +82,7 @@ impl PartialEq for Version {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/db/db_testcontainer/src/lib.rs
+++ b/crates/db/db_testcontainer/src/lib.rs
@@ -16,9 +16,9 @@ pub fn db_test(_attr: TokenStream, stream: TokenStream) -> TokenStream {
     // Clone the function signature for our implementation function
     let impl_sig = sig.clone();
     let fn_name = &sig.ident;
-    let sqlite_fn_name = quote::format_ident!("sqlite_{}", fn_name);
-    let postgres_fn_name = quote::format_ident!("postgres_{}", fn_name);
-    let _test_impl_name = quote::format_ident!("{}_impl", fn_name);
+    let sqlite_fn_name = quote::format_ident!("sqlite_{fn_name}");
+    let postgres_fn_name = quote::format_ident!("postgres_{fn_name}");
+    let _test_impl_name = quote::format_ident!("{fn_name}_impl");
     let _stmts = &block.stmts;
 
     let output = quote! {

--- a/crates/db/migration/src/m20220101_0000010_create_table.rs
+++ b/crates/db/migration/src/m20220101_0000010_create_table.rs
@@ -111,7 +111,7 @@ async fn fill_documentation(db: &SchemaManagerConnection<'_>) -> Result<(), DbEr
         let name = c.unwrap().name;
         let version = cm.version.clone();
         let mut m: cratesio_meta::ActiveModel = cm.into();
-        m.documentation = Set(Some(format!("https://docs.rs/{}/{}", name, version,)));
+        m.documentation = Set(Some(format!("https://docs.rs/{name}/{version}")));
         m.update(db).await?;
     }
     Ok(())

--- a/crates/db/migration/src/m20220101_000004_create_table.rs
+++ b/crates/db/migration/src/m20220101_000004_create_table.rs
@@ -223,8 +223,7 @@ fn get_doc_url(crate_name: &str, crate_version: &Version, settings: &Settings) -
 
     if doc_exists(crate_name, crate_version, settings) {
         Some(format!(
-            "/docs/{}/{}/doc/{}/index.html",
-            crate_name, crate_version, docs_name
+            "/docs/{crate_name}/{crate_version}/doc/{docs_name}/index.html",
         ))
     } else {
         None

--- a/crates/db/migration/src/m20220101_000005_create_table.rs
+++ b/crates/db/migration/src/m20220101_000005_create_table.rs
@@ -421,7 +421,7 @@ async fn fill_crate_index(
             match serde_json::value::to_value(index.deps.clone()) {
                 Ok(v) => Some(v),
                 Err(e) => {
-                    error!("Failed to serialize deps: {}", e);
+                    error!("Failed to serialize deps: {e}");
                     return Err(DbErr::Custom(e.to_string()));
                 }
             }
@@ -433,7 +433,7 @@ async fn fill_crate_index(
             match serde_json::value::to_value(index.features.clone()) {
                 Ok(v) => Some(v),
                 Err(e) => {
-                    error!("Failed to serialize features: {}", e);
+                    error!("Failed to serialize features: {e}");
                     return Err(DbErr::Custom(e.to_string()));
                 }
             }

--- a/crates/db/migration/src/m20220101_000009_create_table.rs
+++ b/crates/db/migration/src/m20220101_000009_create_table.rs
@@ -61,9 +61,9 @@ async fn move_cached_crates(db: &SchemaManagerConnection<'_>) -> Result<(), DbEr
         }
 
         // Move the crate
-        debug!("Moving {} from {:?} to {:?}", name, old, new);
+        debug!("Moving {name} from {old:?} to {new:?}");
         if let Err(e) = std::fs::rename(old, new).map_err(|e| DbErr::Custom(e.to_string())) {
-            debug!("Failed to move {}: {}", name, e);
+            debug!("Failed to move {name}: {e}");
             continue;
         }
     }
@@ -76,12 +76,9 @@ fn get_path(
     name: &str,
     version: &str,
 ) -> (std::path::PathBuf, std::path::PathBuf) {
+    let crate_name = format!("{name}-{version}.crate");
     (
-        settings
-            .bin_path()
-            .join(format!("{}-{}.crate", name, version)),
-        settings
-            .crates_io_bin_path()
-            .join(format!("{}-{}.crate", name, version)),
+        settings.bin_path().join(&crate_name),
+        settings.crates_io_bin_path().join(&crate_name),
     )
 }

--- a/crates/db/migration/src/old_index_metadata.rs
+++ b/crates/db/migration/src/old_index_metadata.rs
@@ -104,8 +104,7 @@ impl OldIndexMetadata {
             .cloned()
             .ok_or_else(|| {
                 DbErr::Custom(format!(
-                    "Could not find version {} in index file {}",
-                    version,
+                    "Could not find version {version} in index file {}",
                     path.display()
                 ))
             })

--- a/crates/db/src/con_string.rs
+++ b/crates/db/src/con_string.rs
@@ -16,7 +16,7 @@ impl Display for ConString {
             ConString::Postgres(p) => p.to_string(),
             ConString::Sqlite(s) => s.to_string(),
         };
-        write!(f, "{}", con_string)
+        write!(f, "{con_string}")
     }
 }
 

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -1161,9 +1161,7 @@ impl DbProvider for Database {
                 Expr::col((CrateMetaIden::Table, CrateMetaIden::CrateFk))
                     .equals((CrateIden::Table, CrateIden::Id)),
             )
-            .and_where(
-                Expr::col((CrateIden::Table, CrateIden::Name)).like(format!("%{}%", contains)),
-            )
+            .and_where(Expr::col((CrateIden::Table, CrateIden::Name)).like(format!("%{contains}%")))
             .and_where(
                 Expr::col((CrateMetaIden::Table, CrateMetaIden::Version))
                     .equals((CrateIden::Table, CrateIden::MaxVersion)),
@@ -1207,7 +1205,7 @@ impl DbProvider for Database {
                         )
                         .and_where(
                             Expr::col((CratesIoIden::Table, CrateIden::OriginalName))
-                                .like(format!("%{}%", contains)),
+                                .like(format!("%{contains}%")),
                         )
                         .to_owned(),
                 )
@@ -1468,7 +1466,6 @@ impl DbProvider for Database {
                 .map_err(|_| DbError::InvalidCrateName(pub_metadata.name.clone()))?,
         );
 
-
         let existing = krate::Entity::find()
             .filter(krate::Column::Name.eq(pub_metadata.name.clone()))
             .one(&self.db_con)
@@ -1476,8 +1473,7 @@ impl DbProvider for Database {
 
         let txn = self.db_con.begin().await?;
 
-        let crate_id = match existing
-        {
+        let crate_id = match existing {
             Some(krate) => {
                 let krate_id = krate.id;
                 let current_max_version = Version::try_from(&krate.max_version)
@@ -1641,14 +1637,12 @@ impl DbProvider for Database {
             .max()
             .ok_or(DbError::FailedToGetMaxVersionByName(crate_name.to_string()))?;
 
-
         let krate = cratesio_crate::Entity::find()
             .filter(cratesio_crate::Column::Name.eq(normalized_name.to_string()))
             .one(&self.db_con)
             .await?;
 
-        let krate = match krate
-        {
+        let krate = match krate {
             Some(krate) => {
                 let mut krate: cratesio_crate::ActiveModel = krate.into();
                 krate.e_tag = Set(etag.to_string());
@@ -1722,8 +1716,8 @@ impl DbProvider for Database {
                     downloads: Set(0),
                     crates_io_fk: Set(krate.id),
                     documentation: Set(Some(format!(
-                        "https://docs.rs/{}/{}",
-                        normalized_name, index.vers,
+                        "https://docs.rs/{normalized_name}/{}",
+                        index.vers,
                     ))),
                 };
 

--- a/crates/db/src/password.rs
+++ b/crates/db/src/password.rs
@@ -3,7 +3,7 @@ use common::util::generate_rand_string;
 const SALT_LENGTH: usize = 10;
 
 pub fn hash_pwd(pwd: &str, salt: &str) -> String {
-    let concat = format!("{}{}", pwd, salt);
+    let concat = format!("{pwd}{salt}");
     sha256::digest(concat)
 }
 

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -20,8 +20,7 @@ pub fn get_doc_url(crate_name: &str, crate_version: &Version, docs_path: &Path) 
 
     if doc_exists(crate_name, crate_version, docs_path) {
         Some(format!(
-            "/docs/{}/{}/doc/{}/index.html",
-            crate_name, crate_version, docs_name
+            "/docs/{crate_name}/{crate_version}/doc/{docs_name}/index.html"
         ))
     } else {
         None
@@ -30,10 +29,7 @@ pub fn get_doc_url(crate_name: &str, crate_version: &Version, docs_path: &Path) 
 
 pub fn compute_doc_url(crate_name: &str, crate_version: &Version) -> String {
     let docs_name = crate_name_to_docs_name(crate_name);
-    format!(
-        "/docs/{}/{}/doc/{}/index.html",
-        crate_name, crate_version, docs_name
-    )
+    format!("/docs/{crate_name}/{crate_version}/doc/{docs_name}/index.html")
 }
 
 fn crate_name_to_docs_name(crate_name: &str) -> String {

--- a/crates/error/src/api_error.rs
+++ b/crates/error/src/api_error.rs
@@ -39,9 +39,9 @@ impl ApiError {
     pub fn new(msg: &str, error: &dyn ToString, status: StatusCode) -> Self {
         let error = error.to_string();
         let e = if error.is_empty() {
-            format!("ERROR: {}", msg)
+            format!("ERROR: {msg}")
         } else {
-            format!("ERROR: {} -> {}", msg, error)
+            format!("ERROR: {msg} -> {error}")
         };
         Self {
             status,
@@ -58,7 +58,7 @@ impl ApiError {
     }
 
     pub fn from_err(e: &dyn std::error::Error, status: StatusCode) -> Self {
-        let e = format!("ERROR: {}", e);
+        let e = format!("ERROR: {e}");
         Self {
             status,
             details: ErrorDetails::from(e),

--- a/crates/index/src/config_json.rs
+++ b/crates/index/src/config_json.rs
@@ -24,12 +24,9 @@ impl ConfigJson {
         auth_required: bool,
     ) -> Self {
         Self {
-            dl: format!(
-                "{}://{}:{}/api/v1/{}/dl",
-                protocol, api_address, api_port, api_path
-            ),
+            dl: format!("{protocol}://{api_address}:{api_port}/api/v1/{api_path}/dl"),
             api: if api_available {
-                Some(format!("{}://{}:{}", protocol, api_address, api_port))
+                Some(format!("{protocol}://{api_address}:{api_port}"))
             } else {
                 None
             },

--- a/crates/kellnr/src/routes/mod.rs
+++ b/crates/kellnr/src/routes/mod.rs
@@ -31,7 +31,7 @@ pub fn create_router(
     );
 
     // Setup docs service
-    let docs_service = get_service(ServeDir::new(format!("{}/docs", data_dir))).route_layer(
+    let docs_service = get_service(ServeDir::new(format!("{data_dir}/docs"))).route_layer(
         middleware::from_fn_with_state(state.clone(), session::session_auth_when_required),
     );
 

--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -308,7 +308,7 @@ pub async fn download(
         .increase_download_counter(&package.to_normalized(), &version)
         .await
     {
-        warn!("Failed to increase download counter: {}", e);
+        warn!("Failed to increase download counter: {e}");
     }
 
     match cs.get(&package, &version).await {
@@ -336,7 +336,7 @@ pub async fn add_empty_crate(
 
     if let Some(id) = db.get_crate_id(&normalized_name).await? {
         let version = match db.get_max_version_from_id(id).await {
-            Ok(v) => format!("{}", v),
+            Ok(v) => format!("{v}"),
             _ => String::new(),
         };
         return Err(RegistryError::CrateExists(data.name, version).into());
@@ -426,8 +426,10 @@ pub async fn publish(
     let created = Utc::now();
 
     // Add crate to DB
-    if let Err(e) = db.add_crate(&pub_data.metadata, &cksum, &created, &token.user)
-        .await {
+    if let Err(e) = db
+        .add_crate(&pub_data.metadata, &cksum, &created, &token.user)
+        .await
+    {
         // On DB error rollback storage insert and bail.
         let _ = cs.delete(&orig_name, &version).await;
         return Err(e.into());

--- a/crates/registry/src/search_params.rs
+++ b/crates/registry/src/search_params.rs
@@ -42,7 +42,7 @@ where
             .map_err(|e| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to extract query parameters: {}", e),
+                    format!("Failed to extract query parameters: {e}"),
                 )
             })?;
 
@@ -58,7 +58,7 @@ where
             .map_err(|e| {
                 (
                     StatusCode::BAD_REQUEST,
-                    format!("Invalid value for per_page: {}", e),
+                    format!("Invalid value for per_page: {e}"),
                 )
             })?;
         let per_page =

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -93,11 +93,11 @@ impl Settings {
     }
 
     pub fn crates_io_path(&self) -> String {
-        format!("{}/cratesio", &self.registry.data_dir)
+        format!("{}/cratesio", self.registry.data_dir)
     }
 
     pub fn crates_path(&self) -> String {
-        format!("{}/crates", &self.registry.data_dir)
+        format!("{}/crates", self.registry.data_dir)
     }
 
     pub fn crates_path_or_bucket(&self) -> String {

--- a/crates/storage/src/cached_crate_storage.rs
+++ b/crates/storage/src/cached_crate_storage.rs
@@ -31,7 +31,7 @@ impl CachedCrateStorage {
     }
 
     fn file_name(name: &str, version: &str) -> String {
-        format!("{}-{}.crate", name, version)
+        format!("{name}-{version}.crate")
     }
 
     pub async fn delete(&self, name: &OriginalName, version: &Version) -> Result<(), StorageError> {
@@ -59,7 +59,7 @@ impl CachedCrateStorage {
                 {
                     return StorageError::CrateExists(name.to_string(), version.to_string());
                 }
-                StorageError::GenericError(format!("Error while adding bin package. Error: {}", e))
+                StorageError::GenericError(format!("Error while adding bin package. Error: {e}"))
             })?;
 
         Ok(sha256::digest(&*crate_data))

--- a/crates/storage/tests/s3_tests.rs
+++ b/crates/storage/tests/s3_tests.rs
@@ -48,7 +48,7 @@ impl TestS3Storage {
 #[tokio::test]
 async fn add_and_get_crate() {
     let host = container.get_host().await.unwrap().to_string();
-    let url = format!("http://{}:{}", host, port);
+    let url = format!("http://{host}:{port}");
     let cratedata = Arc::new([0x00, 0x11, 0x22, 0x33, 0x44]);
     let metadata = PublishMetadata::minimal("Test_Add_crate_binary_Upper-Case", "0.1.0");
     let test_storage = TestS3Storage::from("Test_Add_crate_binary_Upper-Case", &url).await;
@@ -73,7 +73,7 @@ async fn add_and_get_crate() {
 #[tokio::test]
 async fn remove_crate() {
     let host = container.get_host().await.unwrap().to_string();
-    let url = format!("http://{}:{}", host, port);
+    let url = format!("http://{host}:{port}");
     let cratedata = Arc::new([0x00, 0x11, 0x22, 0x33, 0x44]);
     let test_storage = TestS3Storage::from("test_delete", &url).await;
     let name = OriginalName::try_from("test").unwrap();

--- a/crates/web_ui/src/ui.rs
+++ b/crates/web_ui/src/ui.rs
@@ -126,7 +126,7 @@ pub async fn cratesio_data(Query(params): Query<CratesIoDataParams>) -> Result<S
                 match data {
                     Ok(data) => Ok(data),
                     Err(e) => {
-                        error!("Failed to parse crates.io data: {}", e);
+                        error!("Failed to parse crates.io data: {e}");
                         Err(StatusCode::INTERNAL_SERVER_ERROR)
                     }
                 }
@@ -138,7 +138,7 @@ pub async fn cratesio_data(Query(params): Query<CratesIoDataParams>) -> Result<S
             }
         },
         Err(e) => {
-            error!("Failed to get crates.io data: {}", e);
+            error!("Failed to get crates.io data: {e}");
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }
@@ -160,17 +160,17 @@ pub async fn delete_version(
     let name = params.name;
 
     if let Err(e) = state.db.delete_crate(&name.to_normalized(), &version).await {
-        error!("Failed to delete crate from database: {:?}", e);
+        error!("Failed to delete crate from database: {e:?}");
         return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
     }
 
     if let Err(e) = state.crate_storage.delete(&name, &version).await {
-        error!("Failed to delete crate from storage: {}", e);
+        error!("Failed to delete crate from storage: {e}");
         return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
     }
 
     if let Err(e) = docs::delete(&name, &version, &state.settings).await {
-        error!("Failed to delete crate from docs: {}", e);
+        error!("Failed to delete crate from docs: {e}");
         return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
     }
 
@@ -195,17 +195,17 @@ pub async fn delete_crate(
     for cm in crate_meta.iter() {
         let version = Version::from_unchecked_str(&cm.version);
         if let Err(e) = state.db.delete_crate(&name.to_normalized(), &version).await {
-            error!("Failed to delete crate from database: {:?}", e);
+            error!("Failed to delete crate from database: {e:?}");
             return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
         }
 
         if let Err(e) = state.crate_storage.delete(&name, &version).await {
-            error!("Failed to delete crate from storage: {}", e);
+            error!("Failed to delete crate from storage: {e}");
             return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
         }
 
         if let Err(e) = docs::delete(&name, &cm.version, &state.settings).await {
-            error!("Failed to delete crate from docs: {}", e);
+            error!("Failed to delete crate from docs: {e}");
             return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
         }
     }


### PR DESCRIPTION
```
cargo clippy --fix --allow-dirty --workspace --all-targets --all-features
cargo fmt
```

manually fixed `write!(f, "{}", &self.0)` into `write!(f, "{}", self.0)` -- this is faster (compiler is unable to optimize these, and results in about 6% perf cost)

manually fixed a few more cases when the same thing is done in tracing/logging