### PR TITLE
chore: fix implicit_clone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ used_underscore_binding = "allow" # 672
 missing_errors_doc = "allow" # 182
 must_use_candidate = "allow" # 74
 default_trait_access = "allow" # 45
-implicit_clone = "allow" # 32
 cast_possible_truncation = "allow" # 28
 cast_sign_loss = "allow" # 20
 unused_async = "allow" # 16

--- a/crates/db/src/con_string.rs
+++ b/crates/db/src/con_string.rs
@@ -138,8 +138,8 @@ impl From<&Settings> for SqliteConString {
         Self {
             path: settings.sqlite_path(),
             salt: generate_salt(),
-            admin_pwd: settings.setup.admin_pwd.to_owned(),
-            admin_token: settings.setup.admin_token.to_owned(),
+            admin_pwd: settings.setup.admin_pwd.clone(),
+            admin_token: settings.setup.admin_token.clone(),
             session_age: Duration::from_secs(settings.registry.session_age_seconds),
         }
     }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -599,7 +599,7 @@ impl DbProvider for Database {
             .ok_or_else(|| DbError::UserNotFound(user_name.to_owned()))?
             .into();
 
-        u.pwd = Set(hashed.to_owned());
+        u.pwd = Set(hashed.clone());
         u.salt = Set(salt);
 
         u.update(&self.db_con).await?;
@@ -674,7 +674,7 @@ impl DbProvider for Database {
 
         let at = auth_token::ActiveModel {
             name: Set(name.to_owned()),
-            token: Set(hashed_token.to_owned()),
+            token: Set(hashed_token.clone()),
             user_fk: Set(user.id),
             ..Default::default()
         };

--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -164,7 +164,7 @@ pub async fn list_owners(
         .iter()
         .map(|u| crate_user::CrateUser {
             id: u.id,
-            login: u.name.to_owned(),
+            login: u.name.clone(),
             name: None,
         })
         .collect();
@@ -208,7 +208,7 @@ pub async fn list_crate_users(
         .iter()
         .map(|u| crate_user::CrateUser {
             id: u.id,
-            login: u.name.to_owned(),
+            login: u.name.clone(),
             name: None,
         })
         .collect();
@@ -247,7 +247,7 @@ pub async fn list_crate_groups(
         .iter()
         .map(|u| crate_group::CrateGroup {
             id: u.id,
-            name: u.name.to_owned(),
+            name: u.name.clone(),
         })
         .collect();
 

--- a/crates/storage/src/cached_crate_storage.rs
+++ b/crates/storage/src/cached_crate_storage.rs
@@ -70,11 +70,11 @@ impl CachedCrateStorage {
         match self.cache {
             Some(ref cache) => {
                 if let Some(data) = cache.get(&file_name).await {
-                    Some(data.to_vec())
+                    Some(data)
                 } else {
-                    let data = self.storage.get(&file_name).await.ok()?;
-                    cache.insert(file_name.to_owned(), data.to_vec()).await;
-                    Some(data.to_vec())
+                    let data = self.storage.get(&file_name).await.ok()?.to_vec();
+                    cache.insert(file_name.clone(), data.clone()).await;
+                    Some(data)
                 }
             }
             None => self.storage.get(&file_name).await.map(<Vec<u8>>::from).ok(),

--- a/crates/web_ui/src/crate_access.rs
+++ b/crates/web_ui/src/crate_access.rs
@@ -27,7 +27,7 @@ pub async fn list_users(
         .iter()
         .map(|u| CrateUser {
             id: u.id,
-            login: u.name.to_owned(),
+            login: u.name.clone(),
             name: None,
         })
         .collect();
@@ -80,7 +80,7 @@ pub async fn list_groups(
         .iter()
         .map(|u| CrateGroup {
             id: u.id,
-            name: u.name.to_owned(),
+            name: u.name.clone(),
         })
         .collect();
 

--- a/crates/web_ui/src/group.rs
+++ b/crates/web_ui/src/group.rs
@@ -88,7 +88,7 @@ pub async fn list_users(
         .iter()
         .map(|u| GroupUser {
             id: u.id,
-            name: u.name.to_owned(),
+            name: u.name.clone(),
         })
         .collect();
 

--- a/crates/web_ui/src/session.rs
+++ b/crates/web_ui/src/session.rs
@@ -12,7 +12,7 @@ pub trait Name {
 pub struct AdminUser(pub String);
 impl Name for AdminUser {
     fn name(&self) -> String {
-        self.0.to_owned()
+        self.0.clone()
     }
     fn new(name: String) -> Self {
         Self(name)
@@ -22,7 +22,7 @@ impl Name for AdminUser {
 pub struct NormalUser(pub String);
 impl Name for NormalUser {
     fn name(&self) -> String {
-        self.0.to_owned()
+        self.0.clone()
     }
     fn new(name: String) -> Self {
         Self(name)
@@ -32,7 +32,7 @@ impl Name for NormalUser {
 pub struct AnyUser(pub String);
 impl Name for AnyUser {
     fn name(&self) -> String {
-        self.0.to_owned()
+        self.0.clone()
     }
     fn new(name: String) -> Self {
         Self(name)

--- a/crates/web_ui/src/ui.rs
+++ b/crates/web_ui/src/ui.rs
@@ -20,7 +20,7 @@ pub async fn settings(
     State(settings): SettingsState,
 ) -> Result<Json<Settings>, RouteError> {
     user.assert_admin()?;
-    let s: Settings = (*settings).to_owned();
+    let s: Settings = (*settings).clone();
     Ok(Json(s))
 }
 


### PR DESCRIPTION
cloning implies a copy of the same type, whereas `to_owned` is more generic and could apply to things like str and cow

Note that I also removed unneeded clone in `crates/storage/src/cached_crate_storage.rs`