### PR TITLE
[WIP] Implement separate authentication requirements for the UI vs crates API

### DIFF
--- a/crates/index/src/config_json.rs
+++ b/crates/index/src/config_json.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use settings::registry::{AuthRequired, LegacyAuthRequiredWrapper};
 use settings::{Protocol, Settings};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -37,13 +38,19 @@ impl ConfigJson {
 
 impl From<(&Settings, &str, bool)> for ConfigJson {
     fn from(value: (&Settings, &str, bool)) -> Self {
+        let auth_required = match value.0.registry.auth_required {
+            LegacyAuthRequiredWrapper::Deprecated(value) => value,
+            LegacyAuthRequiredWrapper::Current(AuthRequired::All | AuthRequired::OnlyApi) => true,
+            LegacyAuthRequiredWrapper::Current(AuthRequired::No) => false,
+        };
+
         Self::new(
             value.0.origin.protocol,
             &value.0.origin.hostname,
             value.0.origin.port,
             value.1,
             value.2,
-            value.0.registry.auth_required,
+            auth_required,
         )
     }
 }

--- a/crates/settings/src/registry.rs
+++ b/crates/settings/src/registry.rs
@@ -7,7 +7,7 @@ pub struct Registry {
     pub cache_size: u64,
     pub max_crate_size: u64,
     pub max_db_connections: u32,
-    pub auth_required: bool,
+    pub auth_required: LegacyAuthRequiredWrapper,
     pub required_crate_fields: Vec<String>,
     pub new_crates_restricted: bool,
 }
@@ -20,9 +20,66 @@ impl Default for Registry {
             cache_size: 1000,
             max_crate_size: 10 * 1000,
             max_db_connections: 0,
-            auth_required: false,
+            auth_required: LegacyAuthRequiredWrapper::Current(AuthRequired::No),
             required_crate_fields: Vec::new(),
             new_crates_restricted: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, Copy)]
+#[serde(untagged)]
+pub enum LegacyAuthRequiredWrapper {
+    //#[deprecated(note = "Use the new enum variant instead")]
+    Deprecated(bool),
+    Current(AuthRequired),
+}
+
+impl LegacyAuthRequiredWrapper {
+    pub fn for_api(self) -> bool {
+        match self {
+            Self::Deprecated(value) => value,
+            Self::Current(value) => value.for_api(),
+        }
+    }
+
+    pub fn for_ui(self) -> bool {
+        match self {
+            Self::Deprecated(value) => value,
+            Self::Current(value) => value.for_ui(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, Copy)]
+pub enum AuthRequired {
+    No,
+    All,
+    OnlyApi,
+}
+
+impl From<LegacyAuthRequiredWrapper> for AuthRequired {
+    fn from(value: LegacyAuthRequiredWrapper) -> Self {
+        match value {
+            LegacyAuthRequiredWrapper::Deprecated(true) => Self::All,
+            LegacyAuthRequiredWrapper::Deprecated(false) => Self::No,
+            LegacyAuthRequiredWrapper::Current(current) => current,
+        }
+    }
+}
+
+impl AuthRequired {
+    pub fn for_api(self) -> bool {
+        match self {
+            Self::No => false,
+            Self::All | Self::OnlyApi => true,
+        }
+    }
+
+    pub fn for_ui(self) -> bool {
+        match self {
+            Self::No | Self::OnlyApi => false,
+            Self::All => true,
         }
     }
 }

--- a/crates/storage/src/cratesio_crate_storage.rs
+++ b/crates/storage/src/cratesio_crate_storage.rs
@@ -1,6 +1,4 @@
-use crate::{
-    cached_crate_storage::{CachedCrateStorage, DynStorage},    
-};
+use crate::cached_crate_storage::{CachedCrateStorage, DynStorage};
 use settings::Settings;
 use std::ops::{Deref, DerefMut};
 


### PR DESCRIPTION
Initial draft of the implementation.

I am not too happy with the `for_api()` and `for_ui()` functions, any suggestions for a cleaner interface are welcome

Resolves #712 

TODO
=====

- [ ] Finalize type names
- [ ] Update all docs
- [ ] Add (conditional?) deprecated marker to the boolean format
- [ ] Verify which routes should/should not be covered by the new config value