### PR TITLE
add minimal Dockerfile #792

### DIFF
--- a/docker/Dockerfile.minimal
+++ b/docker/Dockerfile.minimal
@@ -1,0 +1,39 @@
+##################
+# Builder image  #
+##################
+FROM alpine:3.22 AS builder
+
+ARG ADMINPWD=admin
+ENV INSTALLDIR=/opt
+ENV DATADIR=/opt/kdata
+ARG AUTHTOKEN=Zy9HhJ02RJmg0GCrgLfaCVfU6IwDfhXD
+ARG VERSION
+
+# Install only what's needed for downloading and extracting
+RUN apk add --no-cache curl zip lscpu sed
+
+# Download and extract in one layer to reduce image size
+WORKDIR ${INSTALLDIR}
+RUN curl -s https://raw.githubusercontent.com/kellnr/installer/main/install.sh | /bin/sh -s -- -m -d ${DATADIR} -p ${ADMINPWD} -t ${AUTHTOKEN} -v ${VERSION}
+
+##################
+# Runtime image  #
+##################
+FROM alpine:3.22
+
+ENV INSTALLDIR=/opt
+ENV DATADIR=/opt/kdata
+
+# Install only runtime dependencies
+RUN apk add --no-cache ca-certificates
+
+# Copy only the necessary files from the builder stage
+COPY --from=builder ${DATADIR} ${DATADIR}
+COPY --from=builder ${INSTALLDIR}/kellnr ${INSTALLDIR}/kellnr
+
+HEALTHCHECK --interval=5m --timeout=3s CMD wget -q --spider http://localhost:8000/api/v1/health || exit 1
+
+EXPOSE 8000
+
+WORKDIR ${INSTALLDIR}/kellnr
+ENTRYPOINT ["/bin/sh", "-c" , "update-ca-certificates && ./kellnr"]

--- a/docker/build_and_push.sh
+++ b/docker/build_and_push.sh
@@ -1,27 +1,52 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+# Define constants
+PLATFORMS="linux/arm/v7,linux/arm64/v8,linux/amd64"
 
 function parse_args {
     echo "STEP: Parse arguments"
-    if [ $# -eq 0 ]; then
-        echo "No arguments supplied"
+    if [ $# -lt 2 ]; then
+        echo "Error: Insufficient arguments"
+        echo "Usage: $0 IMAGE_NAME VERSION [BUILD_TYPE]"
+        echo "  BUILD_TYPE: 'all' (default), 'standard', 'minimal'"
         exit 1
     else
         IMAGE=$1
         VERSION=$2
+        BUILD_TYPE=${3:-"all"}
         echo "Use image: $IMAGE"
         echo "Use version: $VERSION"
+        echo "Build type: $BUILD_TYPE"
+    fi
+}
+
+function validate_version {
+    if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+        echo "Error: Invalid version format. Expected format: X.Y.Z or X.Y.Z-suffix"
+        exit 1
+    fi
+}
+
+function extract_version_parts {
+    # Split the version into an array
+    IFS='.' read -ra VERSION_PARTS <<< "$VERSION"
+    
+    MAJOR=${VERSION_PARTS[0]}
+    MINOR=${VERSION_PARTS[1]}
+    
+    # Handle patch version which might contain pre-release suffix
+    if [[ ${VERSION_PARTS[2]} == *-* ]]; then
+        PATCH=$(echo ${VERSION_PARTS[2]} | cut -d'-' -f1)
+    else
+        PATCH=${VERSION_PARTS[2]}
     fi
 }
 
 function get_tags {
     echo "STEP: Get tags"
-    # Split the version into an array
-    IFS='.' read -ra VERSION_PARTS <<< "$VERSION"
-
-    MAJOR=${VERSION_PARTS[0]}
-    MINOR=${VERSION_PARTS[1]}
-    PATCH=${VERSION_PARTS[2]}
-
+    extract_version_parts
+    
     # Check if VERSION is a pre-release
     if [[ $VERSION == *-* ]]; then
         echo "Version is a pre-release"
@@ -30,22 +55,81 @@ function get_tags {
         echo "Version is a release"
         TAGS="-t $IMAGE:$MAJOR.$MINOR.$PATCH -t $IMAGE:$MAJOR.$MINOR -t $IMAGE:$MAJOR"
     fi
-
+    
     echo "Tags: $TAGS"
 }
 
-function build_and_push {
-  echo "STEP: Build and push"
-  cd .. || exit
-  # shellcheck disable=SC2086
-  docker buildx build . --build-arg VERSION="$VERSION" \
-    --push \
-    --platform linux/arm/v7,linux/arm64/v8,linux/amd64 \
-    -f "./docker/Dockerfile" \
-    $TAGS
-  cd - || exit
+function get_tags_minimal {
+    echo "STEP: Get minimal tags"
+    extract_version_parts
+    
+    # Check if VERSION is a pre-release
+    if [[ $VERSION == *-* ]]; then
+        echo "Version is a pre-release"
+        TAGS_MIN="-t $IMAGE-minimal:$VERSION"
+    else
+        echo "Version is a release"
+        TAGS_MIN="-t $IMAGE-minimal:$MAJOR.$MINOR.$PATCH -t $IMAGE-minimal:$MAJOR.$MINOR -t $IMAGE-minimal:$MAJOR"
+    fi
+    
+    echo "Tags: $TAGS_MIN"
 }
 
+function build_and_push_image {
+    local dockerfile=$1
+    local tags=$2
+    local build_args=$3
+    
+    echo "STEP: Building and pushing with Dockerfile: $dockerfile"
+    cd .. || exit 1
+    # shellcheck disable=SC2086
+    docker buildx build . $build_args \
+        --push \
+        --platform $PLATFORMS \
+        -f "$dockerfile" \
+        $tags
+    
+    local result=$?
+    cd - || exit 1
+    
+    if [ $result -ne 0 ]; then
+        echo "Error: Docker build failed for $dockerfile"
+        exit 1
+    fi
+    
+    echo "Successfully built and pushed $dockerfile"
+}
+
+function build_and_push {
+    build_and_push_image "./docker/Dockerfile" "$TAGS" "--build-arg VERSION=\"$VERSION\""
+}
+
+function build_and_push_minimal {
+    build_and_push_image "./docker/Dockerfile.minimal" "$TAGS_MIN" "--build-arg VERSION=\"$VERSION\""
+}
+
+# Main execution
 parse_args "$@"
+validate_version
 get_tags
-build_and_push
+get_tags_minimal
+
+# Build images based on BUILD_TYPE
+case "$BUILD_TYPE" in
+    "all")
+        build_and_push
+        build_and_push_minimal
+        ;;
+    "standard")
+        build_and_push
+        ;;
+    "minimal")
+        build_and_push_minimal
+        ;;
+    *)
+        echo "Error: Unknown build type '$BUILD_TYPE'"
+        exit 1
+        ;;
+esac
+
+echo "All builds completed successfully!"


### PR DESCRIPTION
Minimal docker image of Kellnr based on Alpine Linux. The image is much smaller than the default image based on Debian, but does not support building rustdocs in the image, as the rust toolchain is missing.