### PR TITLE
S3 creds via service acct corrected

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -104,8 +104,8 @@ pwd = ""
 # Configure S3 as the storage backend instead of the local filesystem
 [s3]
 enabled = false
-access_key = "minioadmin"
-secret_key = "minioadmin"
+access_key = ""
+secret_key = ""
 region = "us-east-1"
 endpoint = "http://localhost:9000"
 allow_http = true

--- a/crates/storage/src/s3_storage.rs
+++ b/crates/storage/src/s3_storage.rs
@@ -76,10 +76,14 @@ impl TryFrom<(&str, &Settings)> for S3Storage {
             s3 = s3.with_region(value);
         }
         if let Some(value) = &settings.s3.access_key {
-            s3 = s3.with_access_key_id(value);
+            if !value.is_empty() {
+                s3 = s3.with_access_key_id(value);
+            }
         }
         if let Some(value) = &settings.s3.secret_key {
-            s3 = s3.with_secret_access_key(value);
+            if !value.is_empty() {
+                s3 = s3.with_secret_access_key(value);
+            }
         }
         // MinIO suitable
         Ok(Self(s3.build()?))


### PR DESCRIPTION
Updates the use of the AmazonS3 crate to allow for the use of a service account (IAM role) for credentials. The change simply skips passing empty values for key id and value to the s3 builder. The will enable the crate to attempt the use of a service acct for gaining credentials.