### PR TITLE
chore: format code and sort imports across multiple files

### DIFF
--- a/crates/appstate/src/lib.rs
+++ b/crates/appstate/src/lib.rs
@@ -1,14 +1,15 @@
+use std::sync::Arc;
+
 use axum::extract::FromRef;
 use axum_extra::extract::cookie::Key;
+use flume::Sender;
 use kellnr_common::cratesio_prefetch_msg::CratesioPrefetchMsg;
 use kellnr_db::DbProvider;
-use flume::Sender;
 use kellnr_settings::Settings;
-use std::sync::Arc;
-use kellnr_storage::{
-    cached_crate_storage::DynStorage, cratesio_crate_storage::CratesIoCrateStorage,
-    fs_storage::FSStorage, kellnr_crate_storage::KellnrCrateStorage,
-};
+use kellnr_storage::cached_crate_storage::DynStorage;
+use kellnr_storage::cratesio_crate_storage::CratesIoCrateStorage;
+use kellnr_storage::fs_storage::FSStorage;
+use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 
 pub type AppState = axum::extract::State<AppStateData>;
 

--- a/crates/auth/src/auth_req_token.rs
+++ b/crates/auth/src/auth_req_token.rs
@@ -1,10 +1,11 @@
-use crate::token::Token;
 use axum::body::Body;
 use axum::extract::{Request, State};
 use axum::http::HeaderValue;
 use axum::middleware::Next;
 use axum::response::Response;
 use tracing::warn;
+
+use crate::token::Token;
 
 /// Middleware that checks if a cargo token is provided when `settings.registry.auth_required` is `true`.
 ///
@@ -47,19 +48,21 @@ pub async fn cargo_auth_when_required(
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use kellnr_appstate::AppStateData;
+    use std::sync::Arc;
+
     use axum::body::Body;
     use axum::http::{Request, StatusCode, header};
     use axum::routing::get;
     use axum::{Router, middleware};
+    use kellnr_appstate::AppStateData;
     use kellnr_db::User;
     use kellnr_db::error::DbError;
     use kellnr_db::mock::MockDb;
-    use mockall::predicate::*;
     use kellnr_settings::Settings;
-    use std::sync::Arc;
+    use mockall::predicate::*;
     use tower::ServiceExt;
+
+    use super::*;
 
     #[tokio::test]
     async fn no_auth_required() {
@@ -170,18 +173,23 @@ mod test {
 
 #[cfg(test)]
 mod auth_middleware_tests {
-    use super::*;
-    use kellnr_appstate::AppStateData;
-    use axum::body::Body;
-    use axum::middleware::from_fn_with_state;
-    use axum::{Router, http::StatusCode, routing::get};
-    use kellnr_db::DbProvider;
-    use kellnr_db::{error::DbError, mock::MockDb};
-    use hyper::{Request, header};
-    use mockall::predicate::*;
-    use kellnr_settings::Settings;
     use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::StatusCode;
+    use axum::middleware::from_fn_with_state;
+    use axum::routing::get;
+    use hyper::{Request, header};
+    use kellnr_appstate::AppStateData;
+    use kellnr_db::DbProvider;
+    use kellnr_db::error::DbError;
+    use kellnr_db::mock::MockDb;
+    use kellnr_settings::Settings;
+    use mockall::predicate::*;
     use tower::ServiceExt;
+
+    use super::*;
 
     fn app_required_auth(db: Arc<dyn DbProvider>) -> Router {
         let settings = Settings::default();

--- a/crates/auth/src/token.rs
+++ b/crates/auth/src/token.rs
@@ -1,15 +1,16 @@
-use kellnr_appstate::AppStateData;
+use std::iter;
+use std::sync::Arc;
+
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::{HeaderMap, StatusCode};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
+use kellnr_appstate::AppStateData;
 use kellnr_db::DbProvider;
 use rand::distr::Alphanumeric;
 use rand::{Rng, rng};
 use serde::Deserialize;
-use std::iter;
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Token {

--- a/crates/common/src/crate_data.rs
+++ b/crates/common/src/crate_data.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
 use crate::index_metadata::IndexDep;
 use crate::publish_metadata::RegistryDep;
-use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CrateData {

--- a/crates/common/src/cratesio_downloader.rs
+++ b/crates/common/src/cratesio_downloader.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
-use tracing::error;
 
 use reqwest::{Client, ClientBuilder, StatusCode};
+use tracing::error;
 
 pub static CLIENT: std::sync::LazyLock<Client> = std::sync::LazyLock::new(|| {
     let mut headers = reqwest::header::HeaderMap::new();

--- a/crates/common/src/cratesio_prefetch_msg.rs
+++ b/crates/common/src/cratesio_prefetch_msg.rs
@@ -1,4 +1,6 @@
-use crate::{normalized_name::NormalizedName, original_name::OriginalName, version::Version};
+use crate::normalized_name::NormalizedName;
+use crate::original_name::OriginalName;
+use crate::version::Version;
 
 pub struct InsertData {
     pub name: OriginalName,

--- a/crates/common/src/index_metadata.rs
+++ b/crates/common/src/index_metadata.rs
@@ -1,13 +1,13 @@
-use crate::{
-    publish_metadata::{PublishMetadata, RegistryDep},
-    version::Version,
-};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter, Write};
 use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
+
+use crate::publish_metadata::{PublishMetadata, RegistryDep};
+use crate::version::Version;
 
 // This Metadata struct defined here is the one saved in the index.
 // It is different to the one send by Cargo to the registry.

--- a/crates/common/src/normalized_name.rs
+++ b/crates/common/src/normalized_name.rs
@@ -1,5 +1,6 @@
-use crate::original_name::OriginalName;
 use std::fmt;
+
+use crate::original_name::OriginalName;
 
 /// Index name is a lowercase version of the crate name
 

--- a/crates/common/src/original_name.rs
+++ b/crates/common/src/original_name.rs
@@ -1,9 +1,11 @@
-use crate::normalized_name::NormalizedName;
-use regex::Regex;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
+
+use regex::Regex;
 use thiserror::Error;
+
+use crate::normalized_name::NormalizedName;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone, Hash)]
 pub struct OriginalName(String);

--- a/crates/common/src/prefetch.rs
+++ b/crates/common/src/prefetch.rs
@@ -1,8 +1,6 @@
-use axum::{
-    body::Body,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use axum::body::Body;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 
 #[derive(Deserialize, PartialEq, Eq, Debug, Clone)]

--- a/crates/common/src/publish_metadata.rs
+++ b/crates/common/src/publish_metadata.rs
@@ -1,6 +1,8 @@
-use crate::index_metadata::IndexDep;
-use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use crate::index_metadata::IndexDep;
 
 // The Metadata struct defined here is the one send by Cargo to the registry.
 // It is different to the one saved in the index!

--- a/crates/common/src/util.rs
+++ b/crates/common/src/util.rs
@@ -1,5 +1,7 @@
-use rand::{Rng, distr::Alphanumeric, rng};
 use std::iter;
+
+use rand::distr::Alphanumeric;
+use rand::{Rng, rng};
 
 pub fn generate_rand_string(length: usize) -> String {
     let mut rng = rng();

--- a/crates/common/src/version.rs
+++ b/crates/common/src/version.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
+
 use thiserror::Error;
 
 #[derive(Debug, Eq, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/db/migration/src/m20220101_0000010_create_table.rs
+++ b/crates/db/migration/src/m20220101_0000010_create_table.rs
@@ -1,9 +1,10 @@
-use crate::sea_orm::ActiveValue::Set;
-use crate::sea_orm::{ActiveModelTrait, EntityTrait};
+use kellnr_settings::{Settings, get_settings};
 use sea_orm::{ModelTrait, Related};
 use sea_orm_migration::prelude::*;
-use kellnr_settings::{Settings, get_settings};
 use tracing::{debug, error};
+
+use crate::sea_orm::ActiveValue::Set;
+use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20220101_000003_create_table.rs
+++ b/crates/db/migration/src/m20220101_000003_create_table.rs
@@ -1,9 +1,10 @@
-use crate::sea_orm::ActiveValue::Set;
-use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 use chrono::NaiveDateTime;
 use kellnr_common::version::Version;
 use sea_orm_migration::prelude::*;
 use tracing::debug;
+
+use crate::sea_orm::ActiveValue::Set;
+use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20220101_000004_create_table.rs
+++ b/crates/db/migration/src/m20220101_000004_create_table.rs
@@ -1,11 +1,12 @@
+use kellnr_common::index_metadata::metadata_path;
+use kellnr_common::version::Version;
+use kellnr_settings::{Settings, get_settings};
+use sea_orm_migration::prelude::*;
+use tracing::{debug, error};
+
 use crate::old_index_metadata::OldIndexMetadata;
 use crate::sea_orm::ActiveValue::Set;
 use crate::sea_orm::{ActiveModelTrait, EntityTrait};
-use kellnr_common::index_metadata::metadata_path;
-use kellnr_common::version::Version;
-use sea_orm_migration::prelude::*;
-use kellnr_settings::{Settings, get_settings};
-use tracing::{debug, error};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20220101_000005_create_table.rs
+++ b/crates/db/migration/src/m20220101_000005_create_table.rs
@@ -1,17 +1,18 @@
+use std::collections::HashMap;
+
+use kellnr_common::index_metadata::metadata_path;
+use kellnr_common::version::Version;
+use kellnr_settings::{Settings, get_settings};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use sea_orm_migration::prelude::*;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error};
+
 use crate::m20220101_000005_create_table_entities::{
     crate_author, crate_author_to_crate, crate_category, crate_category_to_crate, crate_index,
     crate_keyword, crate_keyword_to_crate, crate_meta, krate,
 };
-use crate::old_index_metadata::OldIndexDep;
-use crate::old_index_metadata::OldIndexMetadata;
-use kellnr_common::index_metadata::metadata_path;
-use kellnr_common::version::Version;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
-use sea_orm_migration::prelude::*;
-use serde::{Deserialize, Serialize};
-use kellnr_settings::{Settings, get_settings};
-use std::collections::HashMap;
-use tracing::{debug, error};
+use crate::old_index_metadata::{OldIndexDep, OldIndexMetadata};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20220101_000006_create_table.rs
+++ b/crates/db/migration/src/m20220101_000006_create_table.rs
@@ -1,8 +1,9 @@
-use crate::m20220101_000006_create_table_entities::{crate_index, krate};
 use kellnr_common::index_metadata::IndexMetadata;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 use sea_orm_migration::prelude::*;
 use tracing::debug;
+
+use crate::m20220101_000006_create_table_entities::{crate_index, krate};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20220101_000008_create_table.rs
+++ b/crates/db/migration/src/m20220101_000008_create_table.rs
@@ -1,7 +1,8 @@
-use crate::sea_orm::ActiveValue::Set;
-use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 use sea_orm_migration::prelude::*;
 use tracing::debug;
+
+use crate::sea_orm::ActiveValue::Set;
+use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20220101_000009_create_table.rs
+++ b/crates/db/migration/src/m20220101_000009_create_table.rs
@@ -1,9 +1,10 @@
-use crate::sea_orm::ActiveValue::Set;
-use crate::sea_orm::{ActiveModelTrait, EntityTrait};
+use kellnr_settings::{Settings, get_settings};
 use sea_orm::{ModelTrait, Related};
 use sea_orm_migration::prelude::*;
-use kellnr_settings::{Settings, get_settings};
 use tracing::debug;
+
+use crate::sea_orm::ActiveValue::Set;
+use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20250227_005754_add_readonly_user.rs
+++ b/crates/db/migration/src/m20250227_005754_add_readonly_user.rs
@@ -1,4 +1,5 @@
-use sea_orm_migration::{prelude::*, schema::*};
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
 
 use crate::iden::UserIden;
 

--- a/crates/db/migration/src/m20250412_0000012_hash_tokens.rs
+++ b/crates/db/migration/src/m20250412_0000012_hash_tokens.rs
@@ -1,9 +1,10 @@
-use crate::iden::AuthTokenIden;
-use crate::sea_orm::ActiveValue::Set;
-use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 use sea_orm::{ModelTrait, Related};
 use sea_orm_migration::prelude::*;
 use tracing::debug;
+
+use crate::iden::AuthTokenIden;
+use crate::sea_orm::ActiveValue::Set;
+use crate::sea_orm::{ActiveModelTrait, EntityTrait};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/m20250414_102510_add_unique_indices.rs
+++ b/crates/db/migration/src/m20250414_102510_add_unique_indices.rs
@@ -1,4 +1,5 @@
-use sea_orm_migration::{prelude::*, schema::*};
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
 
 use crate::iden::{
     CrateGroupIden, CrateIndexIden, CrateMetaIden, CrateUserIden, GroupUserIden, OwnerIden,

--- a/crates/db/migration/src/m20250911_000001_cratesio_indices.rs
+++ b/crates/db/migration/src/m20250911_000001_cratesio_indices.rs
@@ -1,4 +1,5 @@
-use sea_orm_migration::{prelude::*, schema::*};
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
 
 use crate::iden::{CratesIoIden, CratesIoIndexIden, CratesIoMetaIden};
 

--- a/crates/db/migration/src/m20250923_095440_webhooks.rs
+++ b/crates/db/migration/src/m20250923_095440_webhooks.rs
@@ -1,4 +1,5 @@
-use sea_orm_migration::{prelude::*, schema::*};
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;

--- a/crates/db/migration/src/old_index_metadata.rs
+++ b/crates/db/migration/src/old_index_metadata.rs
@@ -1,10 +1,11 @@
-use kellnr_common::version::Version;
-use sea_orm::DbErr;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+
+use kellnr_common::version::Version;
+use sea_orm::DbErr;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OldIndexMetadata {

--- a/crates/db/src/con_string.rs
+++ b/crates/db/src/con_string.rs
@@ -1,8 +1,10 @@
-use crate::password::generate_salt;
-use kellnr_settings::Settings;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+
+use kellnr_settings::Settings;
+
+use crate::password::generate_salt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ConString {

--- a/crates/db/src/doc_queue_entry.rs
+++ b/crates/db/src/doc_queue_entry.rs
@@ -1,5 +1,6 @@
-use kellnr_common::normalized_name::NormalizedName;
 use std::path::PathBuf;
+
+use kellnr_common::normalized_name::NormalizedName;
 
 #[derive(Eq, PartialEq, Debug)]
 pub struct DocQueueEntry {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -13,17 +13,14 @@ mod tables;
 mod user;
 
 // Re-exports
-pub use crate::database::{Database, test_utils};
 pub use auth_token::AuthToken;
-pub use con_string::AdminUser;
-pub use con_string::ConString;
-pub use con_string::PgConString;
-pub use con_string::SqliteConString;
+pub use con_string::{AdminUser, ConString, PgConString, SqliteConString};
 pub use crate_meta::CrateMeta;
 pub use crate_summary::CrateSummary;
 pub use doc_queue_entry::DocQueueEntry;
 pub use group::Group;
 pub use krate::Crate;
-pub use provider::DbProvider;
-pub use provider::mock;
+pub use provider::{DbProvider, mock};
 pub use user::User;
+
+pub use crate::database::{Database, test_utils};

--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -1,5 +1,7 @@
-use crate::{AuthToken, CrateSummary, DocQueueEntry, Group, User, crate_meta, error::DbError};
+use std::path::Path;
+
 use chrono::{DateTime, Utc};
+use crate_meta::CrateMeta;
 use kellnr_common::crate_data::CrateData;
 use kellnr_common::crate_overview::CrateOverview;
 use kellnr_common::cratesio_prefetch_msg::CratesioPrefetchMsg;
@@ -10,9 +12,10 @@ use kellnr_common::prefetch::Prefetch;
 use kellnr_common::publish_metadata::PublishMetadata;
 use kellnr_common::version::Version;
 use kellnr_common::webhook::{Webhook, WebhookEvent, WebhookQueue};
-use crate_meta::CrateMeta;
 use sea_orm::prelude::async_trait::async_trait;
-use std::path::Path;
+
+use crate::error::DbError;
+use crate::{AuthToken, CrateSummary, DocQueueEntry, Group, User, crate_meta};
 
 pub type DbResult<T> = Result<T, DbError>;
 #[derive(Debug, PartialEq, Eq)]
@@ -185,10 +188,11 @@ pub trait DbProvider: Send + Sync {
 }
 
 pub mod mock {
-    use super::*;
     use chrono::DateTime;
     use mockall::predicate::*;
     use mockall::*;
+
+    use super::*;
 
     mock! {
           pub Db {}

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
 use chrono::{DateTime, TimeDelta, TimeZone, Utc};
 use kellnr_common::crate_data::{CrateData, CrateRegistryDep, CrateVersionData};
 use kellnr_common::crate_overview::CrateOverview;
@@ -10,11 +13,10 @@ use kellnr_common::version::Version;
 use kellnr_common::webhook::{Webhook, WebhookEvent};
 use kellnr_db::password::hash_pwd;
 use kellnr_db::provider::PrefetchState;
-use kellnr_db::{DbProvider, DocQueueEntry, User, test_utils::*};
+use kellnr_db::test_utils::*;
+use kellnr_db::{DbProvider, DocQueueEntry, User};
 use kellnr_db_testcontainer::db_test;
 use serde_json::json;
-use std::collections::BTreeMap;
-use std::path::PathBuf;
 mod image;
 
 #[db_test]

--- a/crates/db/tests/image.rs
+++ b/crates/db/tests/image.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+
 use testcontainers::Image;
 use testcontainers::core::WaitFor;
 

--- a/crates/docs/src/api.rs
+++ b/crates/docs/src/api.rs
@@ -1,19 +1,18 @@
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::response::Redirect;
+use kellnr_appstate::{AppState, DbState, SettingsState};
+use kellnr_auth::token::Token;
+use kellnr_common::original_name::OriginalName;
+use kellnr_common::version::Version;
+use kellnr_error::api_error::ApiResult;
+use kellnr_registry::kellnr_api::check_ownership;
+
 use crate::doc_archive::DocArchive;
 use crate::doc_queue_response::DocQueueResponse;
 use crate::docs_error::DocsError;
 use crate::upload_response::DocUploadResponse;
 use crate::{compute_doc_url, get_latest_version_with_doc};
-use kellnr_appstate::{AppState, DbState, SettingsState};
-use kellnr_auth::token::Token;
-use axum::{
-    Json,
-    extract::{Path, State},
-    response::Redirect,
-};
-use kellnr_common::original_name::OriginalName;
-use kellnr_common::version::Version;
-use kellnr_error::api_error::ApiResult;
-use kellnr_registry::kellnr_api::check_ownership;
 
 pub async fn docs_in_queue(State(db): DbState) -> ApiResult<Json<DocQueueResponse>> {
     let doc = db.get_doc_queue().await?;
@@ -92,20 +91,22 @@ fn crate_does_not_exist(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::doc_queue_response::DocQueueEntryResponse;
-    use kellnr_appstate::AppStateData;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
     use axum::Router;
     use axum::body::Body;
     use axum::http::Request;
     use axum::routing::get;
+    use http_body_util::BodyExt;
+    use kellnr_appstate::AppStateData;
     use kellnr_common::normalized_name::NormalizedName;
     use kellnr_db::mock::MockDb;
     use kellnr_db::{DbProvider, DocQueueEntry};
-    use http_body_util::BodyExt;
-    use std::path::PathBuf;
-    use std::sync::Arc;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::doc_queue_response::DocQueueEntryResponse;
 
     #[tokio::test]
     async fn doc_in_queue_returns_queue_entries() {

--- a/crates/docs/src/doc_archive.rs
+++ b/crates/docs/src/doc_archive.rs
@@ -1,11 +1,12 @@
-use kellnr_appstate::AppStateData;
+use std::io::Cursor;
+use std::path::Path;
+
 use axum::body::{Body, Bytes};
 use axum::extract::FromRequest;
 use axum::http::Request;
+use kellnr_appstate::AppStateData;
 use kellnr_error::api_error::{ApiError, ApiResult};
 use kellnr_registry::registry_error::RegistryError;
-use std::io::Cursor;
-use std::path::Path;
 use zip::ZipArchive;
 
 type Zip = ZipArchive<Cursor<Vec<u8>>>;

--- a/crates/docs/src/doc_queue.rs
+++ b/crates/docs/src/doc_queue.rs
@@ -1,22 +1,23 @@
-use crate::{compute_doc_url, docs_error::DocsError};
-use cargo::{
-    GlobalContext,
-    core::{Workspace, resolver::CliFeatures},
-    ops::{self, CompileOptions, DocOptions, OutputFormat},
-    util::command_prelude::CompileMode,
-};
-use kellnr_common::{original_name::OriginalName, version::Version};
-use kellnr_db::{DbProvider, DocQueueEntry};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cargo::GlobalContext;
+use cargo::core::Workspace;
+use cargo::core::resolver::CliFeatures;
+use cargo::ops::{self, CompileOptions, DocOptions, OutputFormat};
+use cargo::util::command_prelude::CompileMode;
 use flate2::read::GzDecoder;
 use fs_extra::dir::{CopyOptions, copy};
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use kellnr_common::original_name::OriginalName;
+use kellnr_common::version::Version;
+use kellnr_db::{DbProvider, DocQueueEntry};
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 use tar::Archive;
 use tokio::fs::{create_dir_all, remove_dir_all};
 use tracing::error;
+
+use crate::compute_doc_url;
+use crate::docs_error::DocsError;
 
 pub fn doc_extraction_queue(
     db: Arc<dyn DbProvider>,

--- a/crates/docs/src/doc_queue_response.rs
+++ b/crates/docs/src/doc_queue_response.rs
@@ -28,9 +28,11 @@ impl From<Vec<DocQueueEntry>> for DocQueueResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use kellnr_common::normalized_name::NormalizedName;
     use std::path::PathBuf;
+
+    use kellnr_common::normalized_name::NormalizedName;
+
+    use super::*;
 
     #[test]
     fn doc_queue_response_from_doc_queue_entry() {

--- a/crates/docs/src/docs_error.rs
+++ b/crates/docs/src/docs_error.rs
@@ -1,5 +1,5 @@
-use kellnr_error::api_error::ApiError;
 use hyper::StatusCode;
+use kellnr_error::api_error::ApiError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -5,10 +5,11 @@ pub mod doc_queue_response;
 pub mod docs_error;
 pub mod upload_response;
 
-use kellnr_common::version::Version;
-use kellnr_settings::Settings;
 use std::convert::TryFrom;
 use std::path::Path;
+
+use kellnr_common::version::Version;
+use kellnr_settings::Settings;
 
 pub fn get_latest_doc_url(crate_name: &str, settings: &Settings) -> Option<String> {
     let version = get_latest_version_with_doc(crate_name, settings);

--- a/crates/docs/src/upload_response.rs
+++ b/crates/docs/src/upload_response.rs
@@ -1,7 +1,8 @@
-use crate::compute_doc_url;
 use kellnr_common::original_name::OriginalName;
 use kellnr_common::version::Version;
 use serde::{Deserialize, Serialize};
+
+use crate::compute_doc_url;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DocUploadResponse {
@@ -24,8 +25,9 @@ impl DocUploadResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::convert::TryFrom;
+
+    use super::*;
 
     #[test]
     fn create_new_doc_upload_response_works() {

--- a/crates/embedded-resources/src/lib.rs
+++ b/crates/embedded-resources/src/lib.rs
@@ -1,11 +1,10 @@
-use axum::{
-    body::Body,
-    http::{Response, StatusCode, Uri, header},
-};
+use std::borrow::Cow;
+
+use axum::body::Body;
+use axum::http::{Response, StatusCode, Uri, header};
 use bytes::Bytes;
 use include_dir::{Dir, include_dir};
 use mime_guess::from_path;
-use std::borrow::Cow;
 use tracing::warn;
 
 static STATIC_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/static");

--- a/crates/error/src/api_error.rs
+++ b/crates/error/src/api_error.rs
@@ -1,12 +1,11 @@
-use axum::{
-    Json,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use std::fmt::Display;
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use kellnr_common::original_name::NameError;
 use kellnr_common::version::VersionError;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
 use zip::result::ZipError;
 
 pub type ApiResult<T> = Result<T, ApiError>;

--- a/crates/index/src/config_json.rs
+++ b/crates/index/src/config_json.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use kellnr_settings::{Protocol, Settings};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ConfigJson {
@@ -66,8 +66,9 @@ impl From<(&Settings, &str, bool)> for ConfigJson {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use kellnr_settings::Protocol;
+
+    use super::*;
 
     #[test]
     fn test_config_json_to_json_http() {

--- a/crates/index/src/kellnr_prefetch_api.rs
+++ b/crates/index/src/kellnr_prefetch_api.rs
@@ -1,13 +1,15 @@
-use super::config_json::ConfigJson;
-use kellnr_appstate::{DbState, SettingsState};
-use axum::{
-    Json,
-    extract::{Path, State},
-    http::{HeaderMap, StatusCode},
-};
-use kellnr_common::{normalized_name::NormalizedName, original_name::OriginalName, prefetch::Prefetch};
-use kellnr_db::DbProvider;
 use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use kellnr_appstate::{DbState, SettingsState};
+use kellnr_common::normalized_name::NormalizedName;
+use kellnr_common::original_name::OriginalName;
+use kellnr_common::prefetch::Prefetch;
+use kellnr_db::DbProvider;
+
+use super::config_json::ConfigJson;
 
 #[allow(clippy::unused_async)] // part of the router
 pub async fn config_kellnr(State(settings): SettingsState) -> Json<ConfigJson> {
@@ -55,21 +57,20 @@ fn needs_update(headers: &HeaderMap, prefetch: &Prefetch) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::config_json::ConfigJson;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, header};
+    use axum::routing::get;
+    use http_body_util::BodyExt;
     use kellnr_appstate::AppStateData;
-    use axum::{
-        Router,
-        body::Body,
-        http::{Request, header},
-        routing::get,
-    };
     use kellnr_db::error::DbError;
     use kellnr_db::mock::MockDb;
-    use http_body_util::BodyExt;
-    use mockall::predicate::*;
     use kellnr_settings::{Protocol, Settings};
+    use mockall::predicate::*;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::config_json::ConfigJson;
 
     #[tokio::test]
     async fn config_returns_config_json() {

--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -1,18 +1,23 @@
-use kellnr_appstate::AppStateData;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
 use axum_extra::extract::cookie::Key;
+use kellnr_appstate::AppStateData;
 use kellnr_common::cratesio_prefetch_msg::CratesioPrefetchMsg;
 use kellnr_db::{ConString, Database, DbProvider, PgConString, SqliteConString};
 use kellnr_index::cratesio_prefetch_api::{
     CratesIoPrefetchArgs, UPDATE_CACHE_TIMEOUT_SECS, init_cratesio_prefetch_thread,
 };
-use moka::future::Cache;
 use kellnr_settings::{LogFormat, Settings};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
-use kellnr_storage::{
-    cached_crate_storage::DynStorage, cratesio_crate_storage::CratesIoCrateStorage,
-    fs_storage::FSStorage, kellnr_crate_storage::KellnrCrateStorage, s3_storage::S3Storage,
-};
-use tokio::{fs::create_dir_all, net::TcpListener};
+use kellnr_storage::cached_crate_storage::DynStorage;
+use kellnr_storage::cratesio_crate_storage::CratesIoCrateStorage;
+use kellnr_storage::fs_storage::FSStorage;
+use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
+use kellnr_storage::s3_storage::S3Storage;
+use moka::future::Cache;
+use tokio::fs::create_dir_all;
+use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::fmt::format;
 
@@ -20,7 +25,9 @@ mod routes;
 
 #[tokio::main]
 async fn main() {
-    let settings: Arc<Settings> = kellnr_settings::get_settings().expect("Cannot read config").into();
+    let settings: Arc<Settings> = kellnr_settings::get_settings()
+        .expect("Cannot read config")
+        .into();
     let addr = SocketAddr::from((settings.local.ip, settings.local.port));
 
     // Configure tracing subscriber

--- a/crates/kellnr/src/routes/crate_access_routes.rs
+++ b/crates/kellnr/src/routes/crate_access_routes.rs
@@ -1,8 +1,6 @@
+use axum::Router;
+use axum::routing::{delete, get, put};
 use kellnr_appstate::AppStateData;
-use axum::{
-    Router,
-    routing::{delete, get, put},
-};
 use kellnr_web_ui::crate_access;
 
 /// Creates the crate access routes

--- a/crates/kellnr/src/routes/cratesio_api_routes.rs
+++ b/crates/kellnr/src/routes/cratesio_api_routes.rs
@@ -1,6 +1,7 @@
+use axum::routing::get;
+use axum::{Router, middleware};
 use kellnr_appstate::AppStateData;
 use kellnr_auth::auth_req_token;
-use axum::{Router, middleware, routing::get};
 use kellnr_index::cratesio_prefetch_api;
 use kellnr_registry::cratesio_api;
 

--- a/crates/kellnr/src/routes/docs_routes.rs
+++ b/crates/kellnr/src/routes/docs_routes.rs
@@ -1,13 +1,9 @@
+use axum::extract::DefaultBodyLimit;
+use axum::routing::{get, post, put};
+use axum::{Router, middleware};
 use kellnr_appstate::AppStateData;
-use axum::{
-    Router,
-    extract::DefaultBodyLimit,
-    middleware,
-    routing::{get, post, put},
-};
 use kellnr_docs::api;
-use kellnr_web_ui::session;
-use kellnr_web_ui::ui;
+use kellnr_web_ui::{session, ui};
 
 /// Creates the docs UI routes
 pub fn create_ui_routes(state: AppStateData) -> Router<AppStateData> {

--- a/crates/kellnr/src/routes/group_routes.rs
+++ b/crates/kellnr/src/routes/group_routes.rs
@@ -1,8 +1,6 @@
+use axum::Router;
+use axum::routing::{delete, get, post, put};
 use kellnr_appstate::AppStateData;
-use axum::{
-    Router,
-    routing::{delete, get, post, put},
-};
 use kellnr_web_ui::group;
 
 /// Creates the group routes

--- a/crates/kellnr/src/routes/health_routes.rs
+++ b/crates/kellnr/src/routes/health_routes.rs
@@ -1,5 +1,6 @@
+use axum::Router;
+use axum::routing::get;
 use kellnr_appstate::AppStateData;
-use axum::{Router, routing::get};
 
 /// Health check route
 pub fn create_routes() -> Router<AppStateData> {

--- a/crates/kellnr/src/routes/kellnr_api_routes.rs
+++ b/crates/kellnr/src/routes/kellnr_api_routes.rs
@@ -1,11 +1,8 @@
+use axum::extract::DefaultBodyLimit;
+use axum::routing::{delete, get, put};
+use axum::{Router, middleware};
 use kellnr_appstate::AppStateData;
 use kellnr_auth::auth_req_token;
-use axum::{
-    Router,
-    extract::DefaultBodyLimit,
-    middleware,
-    routing::{delete, get, put},
-};
 use kellnr_index::kellnr_prefetch_api;
 use kellnr_registry::kellnr_api;
 

--- a/crates/kellnr/src/routes/mod.rs
+++ b/crates/kellnr/src/routes/mod.rs
@@ -1,11 +1,9 @@
+use axum::routing::{get, get_service};
+use axum::{Router, middleware};
 use kellnr_appstate::AppStateData;
-use axum::{
-    Router, middleware,
-    routing::{get, get_service},
-};
 use kellnr_embedded_resources::embedded_static_handler;
-use tower_http::services::ServeDir;
 use kellnr_web_ui::session;
+use tower_http::services::ServeDir;
 
 mod crate_access_routes;
 mod cratesio_api_routes;

--- a/crates/kellnr/src/routes/ui_routes.rs
+++ b/crates/kellnr/src/routes/ui_routes.rs
@@ -1,8 +1,6 @@
+use axum::routing::{delete, get};
+use axum::{Router, middleware};
 use kellnr_appstate::AppStateData;
-use axum::{
-    Router, middleware,
-    routing::{delete, get},
-};
 use kellnr_web_ui::{session, ui};
 
 /// Creates the UI API routes (JSON endpoints used by the web frontend).

--- a/crates/kellnr/src/routes/user_routes.rs
+++ b/crates/kellnr/src/routes/user_routes.rs
@@ -1,8 +1,6 @@
+use axum::Router;
+use axum::routing::{delete, get, post};
 use kellnr_appstate::AppStateData;
-use axum::{
-    Router,
-    routing::{delete, get, post},
-};
 use kellnr_web_ui::user;
 
 /// Creates the user routes

--- a/crates/kellnr/src/routes/webhook_routes.rs
+++ b/crates/kellnr/src/routes/webhook_routes.rs
@@ -1,8 +1,6 @@
+use axum::Router;
+use axum::routing::{delete, get, post};
 use kellnr_appstate::AppStateData;
-use axum::{
-    Router,
-    routing::{delete, get, post},
-};
 
 /// Creates the webhook routes
 pub fn create_routes() -> Router<AppStateData> {

--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -1,18 +1,13 @@
-use crate::pub_data::{EmptyCrateData, PubData};
-use crate::pub_success::{EmptyCrateSuccess, PubDataSuccess};
-use crate::registry_error::RegistryError;
-use crate::search_params::SearchParams;
-use crate::yank_success::YankSuccess;
-use crate::{crate_group, crate_user, crate_version};
-use kellnr_appstate::AppState;
-use kellnr_appstate::DbState;
-use kellnr_auth::token;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
 use axum::Json;
-use axum::extract::Path;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::Redirect;
 use chrono::Utc;
+use kellnr_appstate::{AppState, DbState};
+use kellnr_auth::token;
 use kellnr_common::normalized_name::NormalizedName;
 use kellnr_common::original_name::OriginalName;
 use kellnr_common::search_result;
@@ -21,9 +16,14 @@ use kellnr_common::version::Version;
 use kellnr_common::webhook::WebhookEvent;
 use kellnr_db::DbProvider;
 use kellnr_error::api_error::{ApiError, ApiResult};
-use std::convert::TryFrom;
-use std::sync::Arc;
 use tracing::warn;
+
+use crate::pub_data::{EmptyCrateData, PubData};
+use crate::pub_success::{EmptyCrateSuccess, PubDataSuccess};
+use crate::registry_error::RegistryError;
+use crate::search_params::SearchParams;
+use crate::yank_success::YankSuccess;
+use crate::{crate_group, crate_user, crate_version};
 
 pub async fn check_ownership(
     crate_name: &NormalizedName,
@@ -514,30 +514,30 @@ pub async fn unyank(
 
 #[cfg(test)]
 mod reg_api_tests {
-    use super::*;
-    use kellnr_appstate::AppStateData;
+    use std::iter;
+    use std::path::PathBuf;
+
     use axum::Router;
     use axum::body::Body;
-    use axum::http::Request;
-    use axum::http::StatusCode;
+    use axum::http::{Request, StatusCode};
     use axum::routing::{delete, get, put};
+    use http_body_util::BodyExt;
+    use hyper::header;
+    use kellnr_appstate::AppStateData;
     use kellnr_db::mock::MockDb;
     use kellnr_db::{ConString, Database, SqliteConString, test_utils};
     use kellnr_error::api_error::ErrorDetails;
-    use http_body_util::BodyExt;
-    use hyper::header;
-    use mockall::predicate::*;
-    use rand::Rng;
-    use rand::distr::Alphanumeric;
-    use rand::rng;
     use kellnr_settings::Settings;
-    use std::iter;
-    use std::path::PathBuf;
     use kellnr_storage::cached_crate_storage::DynStorage;
     use kellnr_storage::fs_storage::FSStorage;
     use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
+    use mockall::predicate::*;
+    use rand::distr::Alphanumeric;
+    use rand::{Rng, rng};
     use tokio::fs::read;
     use tower::ServiceExt;
+
+    use super::*;
 
     const TOKEN: &str = "854DvwSlUwEHtIo3kWy6x7UCPKHfzCmy";
     const NON_ADMIN_TOKEN: &str = "g8kfzxSrMswNOVio5kBoTEFBBVm3fRS7";

--- a/crates/registry/src/pub_data.rs
+++ b/crates/registry/src/pub_data.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
 
-use crate::registry_error::RegistryError;
-use kellnr_appstate::AppStateData;
 use axum::body::{Body, Bytes};
 use axum::extract::FromRequest;
 use axum::http::Request;
+use kellnr_appstate::AppStateData;
 use kellnr_common::publish_metadata::PublishMetadata;
 use kellnr_error::api_error::ApiError;
-use serde::Deserialize;
 use kellnr_settings::constants::MIN_BODY_CRATE_AND_DOC_BYTES;
+use serde::Deserialize;
+
+use crate::registry_error::RegistryError;
 
 #[derive(Debug, Deserialize)]
 pub struct EmptyCrateData {
@@ -84,16 +85,18 @@ impl FromRequest<AppStateData, Body> for PubData {
 
 #[cfg(test)]
 mod bin_tests {
-    use crate::pub_data::PubData;
+    use std::convert::TryFrom;
+    use std::path::Path;
+
     use kellnr_common::original_name::OriginalName;
     use kellnr_common::publish_metadata::PublishMetadata;
     use kellnr_common::version::Version;
     use kellnr_settings::Settings;
-    use std::{convert::TryFrom, path::Path};
-    use kellnr_storage::{
-        cached_crate_storage::DynStorage, fs_storage::FSStorage,
-        kellnr_crate_storage::KellnrCrateStorage,
-    };
+    use kellnr_storage::cached_crate_storage::DynStorage;
+    use kellnr_storage::fs_storage::FSStorage;
+    use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
+
+    use crate::pub_data::PubData;
 
     struct TestData {
         settings: Settings,

--- a/crates/registry/src/registry_error.rs
+++ b/crates/registry/src/registry_error.rs
@@ -1,5 +1,5 @@
-use kellnr_error::api_error::ApiError;
 use hyper::StatusCode;
+use kellnr_error::api_error::ApiError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/crates/registry/src/search_params.rs
+++ b/crates/registry/src/search_params.rs
@@ -1,7 +1,11 @@
-use axum::{RequestPartsExt, extract::Query, http::request::Parts};
-use kellnr_common::original_name::OriginalName;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use axum::RequestPartsExt;
+use axum::extract::Query;
+use axum::http::request::Parts;
 use hyper::StatusCode;
-use std::{collections::HashMap, convert::TryFrom};
+use kellnr_common::original_name::OriginalName;
 
 pub struct SearchParams {
     pub q: OriginalName,

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -15,14 +15,11 @@ pub mod setup;
 
 pub use docs::Docs;
 pub use local::Local;
-pub use log::LogFormat;
-pub use log::LogLevel;
+pub use log::{LogFormat, LogLevel};
 pub use origin::Origin;
 pub use postgresql::Postgresql;
 pub use protocol::Protocol;
 pub use proxy::Proxy;
 pub use registry::Registry;
-pub use settings::Settings;
-pub use settings::get_settings;
-pub use settings::test_settings;
+pub use settings::{Settings, get_settings, test_settings};
 pub use setup::Setup;

--- a/crates/settings/src/local.rs
+++ b/crates/settings/src/local.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr};
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 #[serde(default)]

--- a/crates/settings/src/log.rs
+++ b/crates/settings/src/log.rs
@@ -1,6 +1,8 @@
-use crate::deserialize_with::DeserializeWith;
-use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::Display;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::deserialize_with::DeserializeWith;
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 #[serde(default)]
@@ -137,8 +139,9 @@ impl From<LogLevel> for tracing::level_filters::LevelFilter {
 
 #[cfg(test)]
 mod log_format_tests {
-    use super::*;
     use serde::Deserialize;
+
+    use super::*;
 
     #[derive(Debug, Deserialize)]
     struct Settings {
@@ -189,8 +192,9 @@ mod log_format_tests {
 
 #[cfg(test)]
 mod log_level_tests {
-    use super::*;
     use serde::Deserialize;
+
+    use super::*;
 
     #[derive(Debug, Deserialize)]
     struct Settings {

--- a/crates/settings/src/origin.rs
+++ b/crates/settings/src/origin.rs
@@ -1,5 +1,6 @@
-use crate::protocol::Protocol;
 use serde::{Deserialize, Serialize};
+
+use crate::protocol::Protocol;
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 #[serde(default)]

--- a/crates/settings/src/protocol.rs
+++ b/crates/settings/src/protocol.rs
@@ -1,5 +1,6 @@
-use crate::deserialize_with::DeserializeWith;
 use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::deserialize_with::DeserializeWith;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Protocol {
@@ -57,8 +58,9 @@ impl Serialize for Protocol {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde::Deserialize;
+
+    use super::*;
 
     #[test]
     fn test_protocol_display() {

--- a/crates/settings/src/registry.rs
+++ b/crates/settings/src/registry.rs
@@ -1,5 +1,6 @@
-use crate::compile_time_config;
 use serde::{Deserialize, Serialize};
+
+use crate::compile_time_config;
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 #[serde(default)]

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -1,7 +1,9 @@
+use std::convert::TryFrom;
+use std::env;
+use std::path::{Path, PathBuf};
+
 use config::{Config, ConfigError, Environment, File};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
-use std::{convert::TryFrom, env, path::Path};
 
 use crate::compile_time_config;
 use crate::docs::Docs;

--- a/crates/storage/src/cached_crate_storage.rs
+++ b/crates/storage/src/cached_crate_storage.rs
@@ -1,9 +1,13 @@
-use crate::{storage::Storage, storage_error::StorageError};
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use kellnr_common::original_name::OriginalName;
 use kellnr_common::version::Version;
-use moka::future::Cache;
 use kellnr_settings::Settings;
-use std::{path::PathBuf, sync::Arc};
+use moka::future::Cache;
+
+use crate::storage::Storage;
+use crate::storage_error::StorageError;
 
 pub type CrateCache = Cache<String, Vec<u8>>;
 pub type DynStorage = Box<dyn Storage + Send + Sync>;

--- a/crates/storage/src/cratesio_crate_storage.rs
+++ b/crates/storage/src/cratesio_crate_storage.rs
@@ -1,6 +1,8 @@
-use crate::cached_crate_storage::{CachedCrateStorage, DynStorage};
-use kellnr_settings::Settings;
 use std::ops::{Deref, DerefMut};
+
+use kellnr_settings::Settings;
+
+use crate::cached_crate_storage::{CachedCrateStorage, DynStorage};
 
 pub struct CratesIoCrateStorage(CachedCrateStorage);
 

--- a/crates/storage/src/fs_storage.rs
+++ b/crates/storage/src/fs_storage.rs
@@ -1,9 +1,13 @@
-use crate::storage::Storage;
-use crate::storage_error::StorageError;
+use std::fs::DirBuilder;
+
 use async_trait::async_trait;
 use bytes::Bytes;
-use object_store::{ObjectStore, ObjectStoreExt, PutMode, local::LocalFileSystem, path::Path};
-use std::fs::DirBuilder;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path;
+use object_store::{ObjectStore, ObjectStoreExt, PutMode};
+
+use crate::storage::Storage;
+use crate::storage_error::StorageError;
 
 pub struct FSStorage(LocalFileSystem);
 

--- a/crates/storage/src/kellnr_crate_storage.rs
+++ b/crates/storage/src/kellnr_crate_storage.rs
@@ -1,14 +1,12 @@
-use crate::{
-    cached_crate_storage::{CachedCrateStorage, DynStorage},
-    storage_error::StorageError,
-};
+use std::ops::{Deref, DerefMut};
+use std::path::{Path, PathBuf};
+
 use kellnr_common::util::generate_rand_string;
 use kellnr_settings::Settings;
-use std::{
-    ops::{Deref, DerefMut},
-    path::{Path, PathBuf},
-};
 use tokio::fs::DirBuilder;
+
+use crate::cached_crate_storage::{CachedCrateStorage, DynStorage};
+use crate::storage_error::StorageError;
 
 pub struct KellnrCrateStorage(CachedCrateStorage);
 

--- a/crates/storage/src/s3_storage.rs
+++ b/crates/storage/src/s3_storage.rs
@@ -1,12 +1,12 @@
-use crate::{storage::Storage, storage_error::StorageError};
 use async_trait::async_trait;
 use bytes::Bytes;
-use object_store::{
-    ObjectStore, ObjectStoreExt, PutMode,
-    aws::{AmazonS3, AmazonS3Builder},
-    path::Path,
-};
 use kellnr_settings::Settings;
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::path::Path;
+use object_store::{ObjectStore, ObjectStoreExt, PutMode};
+
+use crate::storage::Storage;
+use crate::storage_error::StorageError;
 
 pub struct S3Storage(AmazonS3);
 

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -1,6 +1,7 @@
-use crate::storage_error::StorageError;
 use async_trait::async_trait;
 use bytes::Bytes;
+
+use crate::storage_error::StorageError;
 
 #[async_trait]
 pub trait Storage {

--- a/crates/storage/src/storage_error.rs
+++ b/crates/storage/src/storage_error.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/crates/storage/tests/image.rs
+++ b/crates/storage/tests/image.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+
 use testcontainers::Image;
 use testcontainers::core::{ContainerPort, WaitFor};
 

--- a/crates/storage/tests/s3_tests.rs
+++ b/crates/storage/tests/s3_tests.rs
@@ -1,11 +1,12 @@
+use std::convert::TryFrom;
+use std::sync::Arc;
+
 use kellnr_common::original_name::OriginalName;
 use kellnr_common::publish_metadata::PublishMetadata;
 use kellnr_common::version::Version;
 use kellnr_minio_testcontainer::*;
 use kellnr_settings::Settings;
 use kellnr_settings::s3::S3;
-use std::convert::TryFrom;
-use std::sync::Arc;
 use kellnr_storage::cached_crate_storage::DynStorage;
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 use kellnr_storage::s3_storage::S3Storage;

--- a/crates/web-ui/src/crate_access.rs
+++ b/crates/web-ui/src/crate_access.rs
@@ -1,12 +1,13 @@
-use crate::error::RouteError;
-use crate::session::MaybeUser;
-use kellnr_appstate::DbState;
 use axum::Json;
 use axum::extract::{Path, State};
+use kellnr_appstate::DbState;
 use kellnr_common::original_name::OriginalName;
 use kellnr_registry::crate_group::{CrateGroup, CrateGroupList};
 use kellnr_registry::crate_user::{CrateUser, CrateUserList};
 use serde::{Deserialize, Serialize};
+
+use crate::error::RouteError;
+use crate::session::MaybeUser;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccessData {

--- a/crates/web-ui/src/error.rs
+++ b/crates/web-ui/src/error.rs
@@ -1,7 +1,5 @@
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 
 #[derive(Debug)]
 pub enum RouteError {

--- a/crates/web-ui/src/group.rs
+++ b/crates/web-ui/src/group.rs
@@ -1,11 +1,12 @@
-use crate::error::RouteError;
-use crate::session::MaybeUser;
-use kellnr_appstate::DbState;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
+use kellnr_appstate::DbState;
 use kellnr_db::{self, Group};
 use serde::{Deserialize, Serialize};
+
+use crate::error::RouteError;
+use crate::session::MaybeUser;
 
 #[derive(Serialize)]
 pub struct NewTokenResponse {

--- a/crates/web-ui/src/lib.rs
+++ b/crates/web-ui/src/lib.rs
@@ -7,8 +7,9 @@ pub mod user;
 
 #[cfg(test)]
 mod test_helper {
-    use cookie::{Cookie, CookieJar};
     use std::borrow::Cow;
+
+    use cookie::{Cookie, CookieJar};
 
     pub(crate) const TEST_KEY: &[u8] = &[1; 64];
 

--- a/crates/web-ui/src/session.rs
+++ b/crates/web-ui/src/session.rs
@@ -1,8 +1,12 @@
-use crate::error::RouteError;
-use axum::{RequestPartsExt, extract::State};
-use axum::{extract::Request, http::request::Parts, middleware::Next, response::Response};
+use axum::RequestPartsExt;
+use axum::extract::{Request, State};
+use axum::http::request::Parts;
+use axum::middleware::Next;
+use axum::response::Response;
 use axum_extra::extract::PrivateCookieJar;
 use kellnr_settings::constants;
+
+use crate::error::RouteError;
 
 pub trait Name {
     fn name(&self) -> String;
@@ -139,20 +143,26 @@ pub async fn session_auth_when_required(
 
 #[cfg(test)]
 mod session_tests {
-    use super::*;
-    use crate::test_helper::encode_cookies;
-    use kellnr_appstate::AppStateData;
-    use axum::{Router, body::Body, routing::get};
+    use std::result;
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::routing::get;
     use axum_extra::extract::cookie::Key;
-    use kellnr_db::DbProvider;
-    use kellnr_db::{error::DbError, mock::MockDb};
     use hyper::{Request, StatusCode, header};
-    use mockall::predicate::*;
-    use std::{result, sync::Arc};
+    use kellnr_appstate::AppStateData;
+    use kellnr_db::DbProvider;
+    use kellnr_db::error::DbError;
+    use kellnr_db::mock::MockDb;
     use kellnr_storage::cached_crate_storage::DynStorage;
     use kellnr_storage::fs_storage::FSStorage;
     use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
+    use mockall::predicate::*;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helper::encode_cookies;
 
     async fn admin_endpoint(user: MaybeUser) -> result::Result<(), RouteError> {
         user.assert_admin()?;
@@ -415,19 +425,24 @@ mod session_tests {
 
 #[cfg(test)]
 mod auth_middleware_tests {
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::middleware::from_fn_with_state;
+    use axum::routing::get;
+    use axum_extra::extract::cookie::Key;
+    use hyper::{Request, StatusCode, header};
+    use kellnr_appstate::AppStateData;
+    use kellnr_db::DbProvider;
+    use kellnr_db::error::DbError;
+    use kellnr_db::mock::MockDb;
+    use kellnr_settings::Settings;
+    use mockall::predicate::*;
+    use tower::ServiceExt;
+
     use super::*;
     use crate::test_helper::encode_cookies;
-    use kellnr_appstate::AppStateData;
-    use axum::middleware::from_fn_with_state;
-    use axum::{Router, body::Body, routing::get};
-    use axum_extra::extract::cookie::Key;
-    use kellnr_db::DbProvider;
-    use kellnr_db::{error::DbError, mock::MockDb};
-    use hyper::{Request, StatusCode, header};
-    use mockall::predicate::*;
-    use kellnr_settings::Settings;
-    use std::sync::Arc;
-    use tower::ServiceExt;
 
     fn app_required_auth(db: Arc<dyn DbProvider>) -> Router {
         let settings = Settings::default();

--- a/crates/web-ui/src/ui.rs
+++ b/crates/web-ui/src/ui.rs
@@ -1,11 +1,7 @@
-use crate::error::RouteError;
-use crate::session::MaybeUser;
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
 use kellnr_appstate::{AppState, DbState, SettingsState};
-use axum::{
-    Json,
-    extract::{Query, State},
-    http::StatusCode,
-};
 use kellnr_common::crate_data::CrateData;
 use kellnr_common::crate_overview::CrateOverview;
 use kellnr_common::normalized_name::NormalizedName;
@@ -14,6 +10,9 @@ use kellnr_common::version::Version;
 use kellnr_db::error::DbError;
 use kellnr_settings::{Settings, compile_time_config};
 use tracing::error;
+
+use crate::error::RouteError;
+use crate::session::MaybeUser;
 
 #[allow(clippy::unused_async)] // part of the router
 pub async fn settings(
@@ -338,28 +337,29 @@ pub async fn build_rustdoc(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_helper::encode_cookies;
-    use kellnr_appstate::AppStateData;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
     use axum::Router;
     use axum::body::Body;
     use axum::routing::{get, post};
     use axum_extra::extract::cookie::Key;
+    use http_body_util::BodyExt;
+    use hyper::{Request, header};
+    use kellnr_appstate::AppStateData;
     use kellnr_common::crate_data::{CrateRegistryDep, CrateVersionData};
     use kellnr_db::User;
     use kellnr_db::error::DbError;
     use kellnr_db::mock::MockDb;
-    use http_body_util::BodyExt;
-    use hyper::{Request, header};
-    use mockall::predicate::*;
-    use kellnr_settings::Settings;
-    use kellnr_settings::{Postgresql, constants};
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
+    use kellnr_settings::{Postgresql, Settings, constants};
     use kellnr_storage::cached_crate_storage::DynStorage;
     use kellnr_storage::fs_storage::FSStorage;
     use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
+    use mockall::predicate::*;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_helper::encode_cookies;
 
     #[tokio::test]
     async fn settings_no_admin_returns_unauthorized() {

--- a/crates/web-ui/src/user.rs
+++ b/crates/web-ui/src/user.rs
@@ -1,18 +1,19 @@
-use crate::error::RouteError;
-use crate::session::MaybeUser;
-use kellnr_appstate::{AppState, DbState};
-use kellnr_auth::token;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum_extra::extract::PrivateCookieJar;
 use axum_extra::extract::cookie::Cookie;
-use kellnr_common::util::generate_rand_string;
 use cookie::time;
+use kellnr_appstate::{AppState, DbState};
+use kellnr_auth::token;
+use kellnr_common::util::generate_rand_string;
 use kellnr_db::password::generate_salt;
 use kellnr_db::{self, AuthToken, User};
-use serde::{Deserialize, Serialize};
 use kellnr_settings::constants::{COOKIE_SESSION_ID, COOKIE_SESSION_USER};
+use serde::{Deserialize, Serialize};
+
+use crate::error::RouteError;
+use crate::session::MaybeUser;
 
 #[derive(Serialize)]
 pub struct NewTokenResponse {

--- a/crates/webhooks/src/endpoints.rs
+++ b/crates/webhooks/src/endpoints.rs
@@ -1,8 +1,8 @@
-use kellnr_appstate::DbState;
-use kellnr_auth::token;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
+use kellnr_appstate::DbState;
+use kellnr_auth::token;
 use kellnr_common::webhook::Webhook;
 use kellnr_error::api_error::{ApiError, ApiResult};
 
@@ -98,23 +98,23 @@ pub async fn test_webhook(
 
 #[cfg(test)]
 mod endpoint_tests {
-    use kellnr_appstate::AppStateData;
+    use std::sync::Arc;
+
     use axum::Router;
     use axum::body::{Body, to_bytes};
     use axum::http::Request;
     use axum::response::Response;
     use axum::routing::{delete, get, post};
+    use hyper::header;
+    use kellnr_appstate::AppStateData;
     use kellnr_common::webhook::WebhookEvent;
     use kellnr_db::{ConString, Database, DbProvider, SqliteConString};
-    use hyper::header;
     use serde::de::DeserializeOwned;
-    use std::sync::Arc;
     use tower::ServiceExt;
 
+    use super::*;
     use crate::tests::get_test_listener;
     use crate::types::{GetAllWebhooksResponse, GetWebhookResponse, RegisterWebhookResponse};
-
-    use super::*;
 
     const ADMIN_TOKEN: &str = "jkjkashd09128u3019283o1i3j";
     const NON_ADMIN_TOKEN: &str = "kjas09ed8o1i23k1jh";

--- a/crates/webhooks/src/lib.rs
+++ b/crates/webhooks/src/lib.rs
@@ -1,5 +1,7 @@
 use chrono::{DateTime, Utc};
-use kellnr_common::{normalized_name::NormalizedName, version::Version, webhook::WebhookEvent};
+use kellnr_common::normalized_name::NormalizedName;
+use kellnr_common::version::Version;
+use kellnr_common::webhook::WebhookEvent;
 use kellnr_db::DbProvider;
 use serde_json::json;
 

--- a/crates/webhooks/src/service.rs
+++ b/crates/webhooks/src/service.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, TimeDelta, Utc};
 use kellnr_common::webhook::WebhookQueue;
 use kellnr_db::DbProvider;
-use std::sync::Arc;
 
 use crate::types::WebhookError;
 
@@ -105,16 +106,14 @@ mod service_tests {
     use std::sync::Arc;
 
     use chrono::Utc;
-    use kellnr_common::{
-        normalized_name::NormalizedName,
-        version::Version,
-        webhook::{Webhook, WebhookEvent},
-    };
+    use kellnr_common::normalized_name::NormalizedName;
+    use kellnr_common::version::Version;
+    use kellnr_common::webhook::{Webhook, WebhookEvent};
     use kellnr_db::{ConString, Database, DbProvider, SqliteConString};
 
-    use crate::{notify_crate, tests::get_test_listener};
-
     use super::*;
+    use crate::notify_crate;
+    use crate::tests::get_test_listener;
 
     #[tokio::test]
     async fn test_handle_queue_send_ok() {

--- a/crates/webhooks/src/tests.rs
+++ b/crates/webhooks/src/tests.rs
@@ -1,9 +1,7 @@
-use tokio::{
-    io::AsyncWriteExt,
-    net::TcpListener,
-    sync::mpsc::{Receiver, Sender, channel},
-    task::JoinHandle,
-};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::task::JoinHandle;
 
 pub(crate) struct TestListener {
     handle: JoinHandle<()>,

--- a/justfile
+++ b/justfile
@@ -50,6 +50,18 @@ clean-node:
 
 clean-all: clean clean-node
 
+# Reformat all code `cargo fmt`. If nightly is available, use it for better results
+fmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if (rustup toolchain list | grep nightly && rustup component list --toolchain nightly | grep rustfmt) &> /dev/null; then
+        echo 'Reformatting Rust code using nightly Rust fmt to sort imports'
+        cargo +nightly fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate
+    else
+        echo 'Reformatting Rust with the stable cargo fmt.  Install nightly with `rustup install nightly` for better results'
+        cargo fmt --all
+    fi
+
 npm-dev:
 	cd ui && npm run dev
 


### PR DESCRIPTION
Add a new `just fmt` recipe. If nightly is installed, it will normalize the use statements: sorting, grouping by standard vs 3rd party vs internal code.  Without nightly, it simply runs `cargo fmt`.