### PR TITLE
chore: release v5.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "cargo",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "bytes",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "async-std",
  "chrono",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-minio-testcontainer"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "config",
  "serde",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "5.10.0"
+version = "5.10.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "5.10.0"
+version = "5.10.1"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -18,23 +18,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "5.10.0", path = "./crates/appstate" }
-kellnr-auth = { version = "5.10.0", path = "./crates/auth" }
-kellnr-common = { version = "5.10.0", path = "./crates/common" }
-kellnr-db = { version = "5.10.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "5.10.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "5.10.0", path = "./crates/docs" }
-kellnr-entity = { version = "5.10.0", path = "./crates/db/entity" }
-kellnr-error = { version = "5.10.0", path = "./crates/error" }
-kellnr-index = { version = "5.10.0", path = "./crates/index" }
-kellnr-migration = { version = "5.10.0", path = "./crates/db/migration" }
-kellnr-minio-testcontainer = { version = "5.10.0", path = "./crates/storage/minio-testcontainer" }
-kellnr-registry = { version = "5.10.0", path = "./crates/registry" }
-kellnr-settings = { version = "5.10.0", path = "./crates/settings" }
-kellnr-storage = { version = "5.10.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "5.10.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "5.10.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "5.10.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "5.10.1", path = "./crates/appstate" }
+kellnr-auth = { version = "5.10.1", path = "./crates/auth" }
+kellnr-common = { version = "5.10.1", path = "./crates/common" }
+kellnr-db = { version = "5.10.1", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "5.10.1", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "5.10.1", path = "./crates/docs" }
+kellnr-entity = { version = "5.10.1", path = "./crates/db/entity" }
+kellnr-error = { version = "5.10.1", path = "./crates/error" }
+kellnr-index = { version = "5.10.1", path = "./crates/index" }
+kellnr-migration = { version = "5.10.1", path = "./crates/db/migration" }
+kellnr-minio-testcontainer = { version = "5.10.1", path = "./crates/storage/minio-testcontainer" }
+kellnr-registry = { version = "5.10.1", path = "./crates/registry" }
+kellnr-settings = { version = "5.10.1", path = "./crates/settings" }
+kellnr-storage = { version = "5.10.1", path = "./crates/storage" }
+kellnr-web-ui = { version = "5.10.1", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "5.10.1", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "5.10.1", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION



## 🤖 New release

* `kellnr-common`: 5.10.0 -> 5.10.1
* `kellnr-db-testcontainer`: 5.10.0 -> 5.10.1
* `kellnr-entity`: 5.10.0 -> 5.10.1
* `kellnr-settings`: 5.10.0 -> 5.10.1
* `kellnr-migration`: 5.10.0 -> 5.10.1
* `kellnr-db`: 5.10.0 -> 5.10.1
* `kellnr-minio-testcontainer`: 5.10.0 -> 5.10.1
* `kellnr-storage`: 5.10.0 -> 5.10.1
* `kellnr-appstate`: 5.10.0 -> 5.10.1
* `kellnr-auth`: 5.10.0 -> 5.10.1
* `kellnr-error`: 5.10.0 -> 5.10.1
* `kellnr-webhooks`: 5.10.0 -> 5.10.1
* `kellnr-registry`: 5.10.0 -> 5.10.1
* `kellnr-docs`: 5.10.0 -> 5.10.1
* `kellnr-embedded-resources`: 5.10.0 -> 5.10.1
* `kellnr-index`: 5.10.0 -> 5.10.1
* `kellnr-web-ui`: 5.10.0 -> 5.10.1
* `kellnr`: 5.10.0 -> 5.10.1

<details><summary><i><b>Changelog</b></i></summary><p>




















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).