### PR TITLE
chore: release v5.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "cargo",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "bytes",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-minio-testcontainer"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "config",
  "serde",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "5.10.1"
+version = "5.11.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "5.10.1"
+version = "5.11.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -18,23 +18,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "5.10.1", path = "./crates/appstate" }
-kellnr-auth = { version = "5.10.1", path = "./crates/auth" }
-kellnr-common = { version = "5.10.1", path = "./crates/common" }
-kellnr-db = { version = "5.10.1", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "5.10.1", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "5.10.1", path = "./crates/docs" }
-kellnr-entity = { version = "5.10.1", path = "./crates/db/entity" }
-kellnr-error = { version = "5.10.1", path = "./crates/error" }
-kellnr-index = { version = "5.10.1", path = "./crates/index" }
-kellnr-migration = { version = "5.10.1", path = "./crates/db/migration" }
-kellnr-minio-testcontainer = { version = "5.10.1", path = "./crates/storage/minio-testcontainer" }
-kellnr-registry = { version = "5.10.1", path = "./crates/registry" }
-kellnr-settings = { version = "5.10.1", path = "./crates/settings" }
-kellnr-storage = { version = "5.10.1", path = "./crates/storage" }
-kellnr-web-ui = { version = "5.10.1", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "5.10.1", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "5.10.1", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "5.11.0", path = "./crates/appstate" }
+kellnr-auth = { version = "5.11.0", path = "./crates/auth" }
+kellnr-common = { version = "5.11.0", path = "./crates/common" }
+kellnr-db = { version = "5.11.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "5.11.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "5.11.0", path = "./crates/docs" }
+kellnr-entity = { version = "5.11.0", path = "./crates/db/entity" }
+kellnr-error = { version = "5.11.0", path = "./crates/error" }
+kellnr-index = { version = "5.11.0", path = "./crates/index" }
+kellnr-migration = { version = "5.11.0", path = "./crates/db/migration" }
+kellnr-minio-testcontainer = { version = "5.11.0", path = "./crates/storage/minio-testcontainer" }
+kellnr-registry = { version = "5.11.0", path = "./crates/registry" }
+kellnr-settings = { version = "5.11.0", path = "./crates/settings" }
+kellnr-storage = { version = "5.11.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "5.11.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "5.11.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "5.11.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION



## 🤖 New release

* `kellnr-common`: 5.10.1 -> 5.11.0
* `kellnr-db-testcontainer`: 5.10.1 -> 5.11.0
* `kellnr-entity`: 5.10.1 -> 5.11.0
* `kellnr-settings`: 5.10.1 -> 5.11.0
* `kellnr-migration`: 5.10.1 -> 5.11.0
* `kellnr-db`: 5.10.1 -> 5.11.0
* `kellnr-minio-testcontainer`: 5.10.1 -> 5.11.0
* `kellnr-storage`: 5.10.1 -> 5.11.0
* `kellnr-appstate`: 5.10.1 -> 5.11.0
* `kellnr-auth`: 5.10.1 -> 5.11.0
* `kellnr-error`: 5.10.1 -> 5.11.0
* `kellnr-webhooks`: 5.10.1 -> 5.11.0
* `kellnr-registry`: 5.10.1 -> 5.11.0
* `kellnr-docs`: 5.10.1 -> 5.11.0
* `kellnr-embedded-resources`: 5.10.1 -> 5.11.0
* `kellnr-index`: 5.10.1 -> 5.11.0
* `kellnr-web-ui`: 5.10.1 -> 5.11.0
* `kellnr`: 5.10.1 -> 5.11.0

<details><summary><i><b>Changelog</b></i></summary><p>




















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).