### PR TITLE
chore: release v5.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.11.1](https://github.com/kellnr/kellnr/compare/v5.11.0...v5.11.1) - 2026-01-17
+
+### Other
+
+- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))
+- update Cargo.lock dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "cargo",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "bytes",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "async-std",
  "chrono",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-minio-testcontainer"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "config",
  "serde",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "5.11.0"
+version = "5.11.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "5.11.0"
+version = "5.11.1"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -18,23 +18,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "5.11.0", path = "./crates/appstate" }
-kellnr-auth = { version = "5.11.0", path = "./crates/auth" }
-kellnr-common = { version = "5.11.0", path = "./crates/common" }
-kellnr-db = { version = "5.11.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "5.11.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "5.11.0", path = "./crates/docs" }
-kellnr-entity = { version = "5.11.0", path = "./crates/db/entity" }
-kellnr-error = { version = "5.11.0", path = "./crates/error" }
-kellnr-index = { version = "5.11.0", path = "./crates/index" }
-kellnr-migration = { version = "5.11.0", path = "./crates/db/migration" }
-kellnr-minio-testcontainer = { version = "5.11.0", path = "./crates/storage/minio-testcontainer" }
-kellnr-registry = { version = "5.11.0", path = "./crates/registry" }
-kellnr-settings = { version = "5.11.0", path = "./crates/settings" }
-kellnr-storage = { version = "5.11.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "5.11.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "5.11.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "5.11.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "5.11.1", path = "./crates/appstate" }
+kellnr-auth = { version = "5.11.1", path = "./crates/auth" }
+kellnr-common = { version = "5.11.1", path = "./crates/common" }
+kellnr-db = { version = "5.11.1", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "5.11.1", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "5.11.1", path = "./crates/docs" }
+kellnr-entity = { version = "5.11.1", path = "./crates/db/entity" }
+kellnr-error = { version = "5.11.1", path = "./crates/error" }
+kellnr-index = { version = "5.11.1", path = "./crates/index" }
+kellnr-migration = { version = "5.11.1", path = "./crates/db/migration" }
+kellnr-minio-testcontainer = { version = "5.11.1", path = "./crates/storage/minio-testcontainer" }
+kellnr-registry = { version = "5.11.1", path = "./crates/registry" }
+kellnr-settings = { version = "5.11.1", path = "./crates/settings" }
+kellnr-storage = { version = "5.11.1", path = "./crates/storage" }
+kellnr-web-ui = { version = "5.11.1", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "5.11.1", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "5.11.1", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"

--- a/crates/appstate/CHANGELOG.md
+++ b/crates/appstate/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/auth/CHANGELOG.md
+++ b/crates/auth/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/common/CHANGELOG.md
+++ b/crates/common/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-common-v5.11.0...kellnr-common-v5.11.1) - 2026-01-17
+
+### Other
+
+- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))

--- a/crates/db/CHANGELOG.md
+++ b/crates/db/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-db-v5.11.0...kellnr-db-v5.11.1) - 2026-01-17
+
+### Other
+
+- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))

--- a/crates/db/db-testcontainer/CHANGELOG.md
+++ b/crates/db/db-testcontainer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/db/entity/CHANGELOG.md
+++ b/crates/db/entity/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/db/migration/CHANGELOG.md
+++ b/crates/db/migration/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-migration-v5.11.0...kellnr-migration-v5.11.1) - 2026-01-17
+
+### Other
+
+- update Cargo.lock dependencies

--- a/crates/docs/CHANGELOG.md
+++ b/crates/docs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/embedded-resources/CHANGELOG.md
+++ b/crates/embedded-resources/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-embedded-resources-v5.11.0...kellnr-embedded-resources-v5.11.1) - 2026-01-17
+
+### Other
+
+- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))

--- a/crates/error/CHANGELOG.md
+++ b/crates/error/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/index/CHANGELOG.md
+++ b/crates/index/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/registry/CHANGELOG.md
+++ b/crates/registry/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/settings/CHANGELOG.md
+++ b/crates/settings/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/storage/CHANGELOG.md
+++ b/crates/storage/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-storage-v5.11.0...kellnr-storage-v5.11.1) - 2026-01-17
+
+### Other
+
+- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))

--- a/crates/storage/minio-testcontainer/CHANGELOG.md
+++ b/crates/storage/minio-testcontainer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/web-ui/CHANGELOG.md
+++ b/crates/web-ui/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/webhooks/CHANGELOG.md
+++ b/crates/webhooks/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION



## 🤖 New release

* `kellnr-common`: 5.11.0 -> 5.11.1
* `kellnr-db-testcontainer`: 5.11.0 -> 5.11.1
* `kellnr-entity`: 5.11.0 -> 5.11.1
* `kellnr-settings`: 5.11.0 -> 5.11.1
* `kellnr-migration`: 5.11.0 -> 5.11.1
* `kellnr-db`: 5.11.0 -> 5.11.1
* `kellnr-minio-testcontainer`: 5.11.0 -> 5.11.1
* `kellnr-storage`: 5.11.0 -> 5.11.1
* `kellnr-appstate`: 5.11.0 -> 5.11.1
* `kellnr-auth`: 5.11.0 -> 5.11.1
* `kellnr-error`: 5.11.0 -> 5.11.1
* `kellnr-webhooks`: 5.11.0 -> 5.11.1
* `kellnr-registry`: 5.11.0 -> 5.11.1
* `kellnr-docs`: 5.11.0 -> 5.11.1
* `kellnr-embedded-resources`: 5.11.0 -> 5.11.1
* `kellnr-index`: 5.11.0 -> 5.11.1
* `kellnr-web-ui`: 5.11.0 -> 5.11.1
* `kellnr`: 5.11.0 -> 5.11.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `kellnr-common`

<blockquote>

## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-common-v5.11.0...kellnr-common-v5.11.1) - 2026-01-17

### Other

- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))
</blockquote>




## `kellnr-migration`

<blockquote>

## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-migration-v5.11.0...kellnr-migration-v5.11.1) - 2026-01-17

### Other

- update Cargo.lock dependencies
</blockquote>

## `kellnr-db`

<blockquote>

## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-db-v5.11.0...kellnr-db-v5.11.1) - 2026-01-17

### Other

- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))
</blockquote>


## `kellnr-storage`

<blockquote>

## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-storage-v5.11.0...kellnr-storage-v5.11.1) - 2026-01-17

### Other

- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))
</blockquote>







## `kellnr-embedded-resources`

<blockquote>

## [5.11.1](https://github.com/kellnr/kellnr/compare/kellnr-embedded-resources-v5.11.0...kellnr-embedded-resources-v5.11.1) - 2026-01-17

### Other

- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))
</blockquote>



## `kellnr`

<blockquote>

## [5.11.1](https://github.com/kellnr/kellnr/compare/v5.11.0...v5.11.1) - 2026-01-17

### Other

- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))
- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).