### PR TITLE
ci: Run the CI job only on pull

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,8 @@
 name: kellnr-ci
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
-      - devel
   release:
     types:
       - published


### PR DESCRIPTION
Currently the CI job runs on every push to main, which leads to double CI runs as the CI is already ran in the PR.