### PR TITLE
ci: refactor YAML syntax for consistency and readability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+        with: { nix_path: 'nixpkgs=channel:nixos-unstable' }
 
       - name: Tests
         run: nix develop --command just test
@@ -41,8 +40,7 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+        with: { nix_path: 'nixpkgs=channel:nixos-unstable' }
 
       - name: Tests
         run: nix develop --command just test-pgdb
@@ -56,8 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+        with: { nix_path: 'nixpkgs=channel:nixos-unstable' }
 
       - name: Tests
         run: nix develop --command just test-smoke
@@ -68,8 +65,7 @@ jobs:
     name: Kellnr Build
     if: github.event_name == 'release'
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
+    permissions: { contents: write }
     strategy:
       matrix:
         target:
@@ -92,8 +88,7 @@ jobs:
 
       - name: Install Just
         uses: taiki-e/install-action@v2
-        with:
-          tool: just
+        with: { tool: just }
 
       - name: Setup Rust
         uses: hecrj/setup-rust-action@v2
@@ -114,10 +109,10 @@ jobs:
       - name: Build Release {{ matrix.target }}
         run: just target=${{ matrix.target }} ci-release
 
-      - name: Set Packagename
+      - name: Set Package Name
         run: echo "KELLNR_PACKAGE=kellnr-${{ matrix.target }}-$KELLNR_VERSION.zip" >> $GITHUB_ENV
 
-      - name: Print Packagename
+      - name: Print Package Name
         run: echo $KELLNR_PACKAGE
 
       - name: Package Config
@@ -150,9 +145,7 @@ jobs:
       - test-kellnr
       - test-kellnr-pgdb
       - test-kellnr-smoke
-    permissions:
-      packages: write
-      contents: read
+    permissions: { packages: write, contents: read }
     env:
       IMAGE: ghcr.io/kellnr/kellnr
 
@@ -183,21 +176,17 @@ jobs:
     name: Release to crates.io
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    needs:
-      - build-and-push-image
+    needs: [ build-and-push-image ]
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+        with: { fetch-depth: 0, persist-credentials: false }
 
       - name: Install Just
         uses: taiki-e/install-action@v2
-        with:
-          tool: just
+        with: { tool: just }
 
       - name: Setup Rust
         uses: hecrj/setup-rust-action@v2

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,26 +11,21 @@ jobs:
     name: Release-plz PR
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'kellnr' }}
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: { contents: write, pull-requests: write }
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+        with: { fetch-depth: 0, persist-credentials: false }
 
       - name: Setup Rust
         uses: hecrj/setup-rust-action@v2
 
       - name: Run release-plz
         uses: release-plz/action@v0.5
-        with:
-          command: release-pr
+        with: { command: release-pr }
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -39,23 +34,17 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    permissions: { contents: write }
     if: ${{ github.repository_owner == 'kellnr' }}
     steps:
-      - &checkout
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - &install-rust
-        name: Install Rust toolchain
+        with: { fetch-depth: 0, persist-credentials: false }
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: release-plz/action@v0.5
-        with:
-          command: release
+        with: { command: release }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Also removed unused anchor-yaml-magic stuff.  I have been looking at how to simplify the CI, but this one is just a minor linting PR.

At the moment, there are a lot of manual steps that you may want to modify in the future (TBD, should probably start a new ticket):

* on PR
  * run all validation jobs
* on push to main
  * run the same jobs as run on PR
  * run all packaging jobs
  * run release-plz (could run as a simpler single job after a gate check for all prior steps, see [here](https://github.com/oxibus/automotive_diag/blob/944e7ea6777d97a3c4352e246eab2657ad0166e1/.github/workflows/ci.yml#L74)).  Here, release-plz may want to auto-publish all packages itself, rather than do it in a separate "on-release" trigger.
 
The current per-package `cargo publish` seems wrong, but I might be missing something though.