### PR TITLE
chore: release v5.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "cargo",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "bytes",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-minio-testcontainer"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "config",
  "serde",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "5.14.0"
+version = "5.15.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "5.14.0"
+version = "5.15.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -18,23 +18,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "5.14.0", path = "./crates/appstate" }
-kellnr-auth = { version = "5.14.0", path = "./crates/auth" }
-kellnr-common = { version = "5.14.0", path = "./crates/common" }
-kellnr-db = { version = "5.14.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "5.14.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "5.14.0", path = "./crates/docs" }
-kellnr-entity = { version = "5.14.0", path = "./crates/db/entity" }
-kellnr-error = { version = "5.14.0", path = "./crates/error" }
-kellnr-index = { version = "5.14.0", path = "./crates/index" }
-kellnr-migration = { version = "5.14.0", path = "./crates/db/migration" }
-kellnr-minio-testcontainer = { version = "5.14.0", path = "./crates/storage/minio-testcontainer" }
-kellnr-registry = { version = "5.14.0", path = "./crates/registry" }
-kellnr-settings = { version = "5.14.0", path = "./crates/settings" }
-kellnr-storage = { version = "5.14.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "5.14.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "5.14.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "5.14.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "5.15.0", path = "./crates/appstate" }
+kellnr-auth = { version = "5.15.0", path = "./crates/auth" }
+kellnr-common = { version = "5.15.0", path = "./crates/common" }
+kellnr-db = { version = "5.15.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "5.15.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "5.15.0", path = "./crates/docs" }
+kellnr-entity = { version = "5.15.0", path = "./crates/db/entity" }
+kellnr-error = { version = "5.15.0", path = "./crates/error" }
+kellnr-index = { version = "5.15.0", path = "./crates/index" }
+kellnr-migration = { version = "5.15.0", path = "./crates/db/migration" }
+kellnr-minio-testcontainer = { version = "5.15.0", path = "./crates/storage/minio-testcontainer" }
+kellnr-registry = { version = "5.15.0", path = "./crates/registry" }
+kellnr-settings = { version = "5.15.0", path = "./crates/settings" }
+kellnr-storage = { version = "5.15.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "5.15.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "5.15.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "5.15.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v5.15.0

This release updates all workspace packages to version **5.15.0**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-minio-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [5.15.0](https://github.com/kellnr/kellnr/compare/v5.14.0...v5.15.0) - 2026-01-24

### Added

- promote user to admin ([#980](https://github.com/kellnr/kellnr/pull/980))
- redirect to auth tokens on /me ([#974](https://github.com/kellnr/kellnr/pull/974))
- add "pubtime" index field ([#970](https://github.com/kellnr/kellnr/pull/970))
- improved UI ([#966](https://github.com/kellnr/kellnr/pull/966))
- Make cards on frontpage clickable ([#964](https://github.com/kellnr/kellnr/pull/964))
- implement token cache, to relieve some pressure on db and in high throughput scenarios ([#953](https://github.com/kellnr/kellnr/pull/953))
- Configurable cookie signing key #928 ([#951](https://github.com/kellnr/kellnr/pull/951))
- Allow configuration of proxy URL and index #880 ([#954](https://github.com/kellnr/kellnr/pull/954))
- Add allow_ownerless_crates setting ([#952](https://github.com/kellnr/kellnr/pull/952))
- add & remove crate owners in UI  #699 ([#940](https://github.com/kellnr/kellnr/pull/940))
- Show available crate groups in dropdown element in UI #700 ([#929](https://github.com/kellnr/kellnr/pull/929))
- allow env-var S3 config
- *(crates/auth)* handle bearer token and basic authentication

### Fixed

- libstd not found on macOS
- Broken crc dependency in lzma-rust2 crate ([#943](https://github.com/kellnr/kellnr/pull/943))
- Update workspace dependencies
- broken config and data dir path #902 ([#903](https://github.com/kellnr/kellnr/pull/903))
- fix clippy lints
- fix tests #881
- fix smoke test #881
- fix clippy warnings

fix

fix

fix

fix
- fix #818

Parse "required crate field" correctly from an env var
- fix #786

Fix broken caching for docs
- fix docs queue
- fix typo
- fix #802 failing health check

Fixes the failing healthcheck in the minimal dockerfile
- fix test-smoke docker image build
- fix dark font on dark mode

Set the font color of the startup config values to white if the dark
mode is enabled
- fix list in readme
- fix list in readme
- fix script
- fix pg test image
- fix check for file existence #760
- fix #771
- addex x64 platform support to ui/nix.
- updated ui/nix to reflect package.json.
- fix #756

Add a separate health route that is never behind authentication
- fix #756

Add a separate health route that is never behind authentication
- fix comment
- fix ci
- fix typo
- fix latest release in smoke test
- fix warnings

fix warnings
- fix missing data dir
- fix formatting
- fix npm deps in flake.nix
- fix #430
- fix #602 - Login not correctly working
- fix status messages for crate users
- fix #583
- fix padding in readme rendering
- fix missing crate description
- fix crates.io migration
- fix typo
- fix flaky test
- fix flake
- fix ci even more
- fix ci again times 10
- fix error in justfile
- fix #356
- fix UTC plugin
- fix utc issue #355
- fix utc issue #355
- fix #355
- fix missing dir
- fix package.jso
- fix crane lib

### Other

- improve performance of UI tests ([#981](https://github.com/kellnr/kellnr/pull/981))
- *(deps)* bump object_store from 0.13.0 to 0.13.1 ([#978](https://github.com/kellnr/kellnr/pull/978))
- *(deps)* bump time from 0.3.45 to 0.3.46 ([#979](https://github.com/kellnr/kellnr/pull/979))
- *(deps)* bump object_store from 0.13.0 to 0.13.1
- *(deps)* bump time from 0.3.45 to 0.3.46
- *(deps)* bump quote from 1.0.43 to 1.0.44 ([#975](https://github.com/kellnr/kellnr/pull/975))
- *(deps)* bump thiserror from 2.0.17 to 2.0.18 ([#976](https://github.com/kellnr/kellnr/pull/976))
- *(deps)* bump thiserror from 2.0.17 to 2.0.18
- *(deps)* bump quote from 1.0.43 to 1.0.44
- enforce fmt and no clippy warnings ([#973](https://github.com/kellnr/kellnr/pull/973))
- remove cargo-deny ([#972](https://github.com/kellnr/kellnr/pull/972))
- make UI code more maintainable ([#968](https://github.com/kellnr/kellnr/pull/968))
- move crate.io publish further up the pipeline
- add workflow trigger
- Merge branch 'main' of github.com:kellnr/kellnr
- switch from release-plz to k-releaser ([#965](https://github.com/kellnr/kellnr/pull/965))
- Add UI tests and port smoke tests
- *(deps)* bump montudor/action-zip from 0.1.1 to 1.0.0 ([#961](https://github.com/kellnr/kellnr/pull/961))
- *(deps)* bump montudor/action-zip from 0.1.1 to 1.0.0
- refactor YAML syntax for consistency and readability ([#958](https://github.com/kellnr/kellnr/pull/958))
- update Cargo.toml deps, clean up configuration ([#960](https://github.com/kellnr/kellnr/pull/960))
- add .editorconfig for consistent coding styles ([#959](https://github.com/kellnr/kellnr/pull/959))
- Remove unused token from Tests step in CI
- improve release-plz config ([#957](https://github.com/kellnr/kellnr/pull/957))
- Update release notes parser
- Disable release-plz release
- Run the CI job only on pull ([#956](https://github.com/kellnr/kellnr/pull/956))
- Run CI only in kellnr org and not in forks
- Add auto-release creation
- Group "crate access" settings and document usage in crate settings
- Merge branch 'main' of github.com:kellnr/kellnr
- Update flake.nix
- Update Rust Docker images ([#944](https://github.com/kellnr/kellnr/pull/944))
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- Fix cargo publish
- add "cargo publish" step
- Package default config in release zip
- run "cargo clean" before build
- clean all artifacts before build
- fix latest kellnr image resolve ([#941](https://github.com/kellnr/kellnr/pull/941))
- 921 publish to kellnr to cratesio ([#939](https://github.com/kellnr/kellnr/pull/939))
- *(deps)* bump serde_json from 1.0.148 to 1.0.149 ([#938](https://github.com/kellnr/kellnr/pull/938))
- *(deps)* bump syn from 2.0.113 to 2.0.114 ([#937](https://github.com/kellnr/kellnr/pull/937))
- *(deps)* bump quote from 1.0.42 to 1.0.43 ([#936](https://github.com/kellnr/kellnr/pull/936))
- *(deps)* bump toml from 0.9.10+spec-1.1.0 to 0.9.11+spec-1.1.0 ([#935](https://github.com/kellnr/kellnr/pull/935))
- *(deps)* bump url from 2.5.7 to 2.5.8 ([#934](https://github.com/kellnr/kellnr/pull/934))
- *(deps)* bump dependabot/fetch-metadata from 2.4.0 to 2.5.0 ([#933](https://github.com/kellnr/kellnr/pull/933))
- *(deps)* bump serde_json from 1.0.148 to 1.0.149
- *(deps)* bump syn from 2.0.113 to 2.0.114
- *(deps)* bump quote from 1.0.42 to 1.0.43
- *(deps)* bump toml from 0.9.10+spec-1.1.0 to 0.9.11+spec-1.1.0
- *(deps)* bump url from 2.5.7 to 2.5.8
- *(deps)* bump dependabot/fetch-metadata from 2.4.0 to 2.5.0
- Update sea-orm dependencies to latest rc ([#932](https://github.com/kellnr/kellnr/pull/932))
- *(deps)* bump rsa from 0.9.9 to 0.9.10 ([#927](https://github.com/kellnr/kellnr/pull/927))
- *(deps)* bump rsa from 0.9.9 to 0.9.10
- Prepare for crates.io publishing ([#926](https://github.com/kellnr/kellnr/pull/926))
- format code and sort imports across multiple files ([#922](https://github.com/kellnr/kellnr/pull/922))
- *(deps-dev)* bump globals from 16.5.0 to 17.0.0 in /ui ([#925](https://github.com/kellnr/kellnr/pull/925))
- *(deps)* bump syn from 2.0.111 to 2.0.112 ([#924](https://github.com/kellnr/kellnr/pull/924))
- *(deps-dev)* bump globals from 16.5.0 to 17.0.0 in /ui
- *(deps)* bump syn from 2.0.111 to 2.0.112
- rename all crates to kebap-case with a kellnr-*  prefix #913 ([#920](https://github.com/kellnr/kellnr/pull/920))
- 916 pre compiled ui resources ([#917](https://github.com/kellnr/kellnr/pull/917))

- **refactor: move embedded web resources into own crate #916**
- [WIP] Update license to dual MIT and Apache 2.0 ([#919](https://github.com/kellnr/kellnr/pull/919))

- [x] Add Apache-2.0 LICENSE file (LICENSE-APACHE)
- [x] Rename current LICENSE to LICENSE-MIT
- [x] Update workspace license in Cargo.toml from "MIT" to "MIT OR
Apache-2.0"
- use `license` field and other Cargo.toml cleanups ([#912](https://github.com/kellnr/kellnr/pull/912))
- replace-lua-tests-with-playwright ([#910](https://github.com/kellnr/kellnr/pull/910))
- use workspace version everywhere
- Add release-plz ([#908](https://github.com/kellnr/kellnr/pull/908))
- reflect auto update in website
- Add pipeline to update website automatically ([#904](https://github.com/kellnr/kellnr/pull/904))
- re-enable smoke test in ci pipeline
- temporary disable smoke test
- Update contribution guide
- fix missing permission
- remove package step for resources
- dispatch release event to helm repo ([#900](https://github.com/kellnr/kellnr/pull/900))
- Merge branch 'main' of github.com:kellnr/kellnr
- update object_store dependency
- *(deps)* bump actions/checkout from 4 to 6 ([#893](https://github.com/kellnr/kellnr/pull/893))
- update node packages
- *(deps)* bump testcontainers from 0.26.2 to 0.26.3 ([#896](https://github.com/kellnr/kellnr/pull/896))
- Merge branch 'main' into dependabot/github_actions/actions/checkout-6
- *(deps)* bump axum-extra from 0.12.3 to 0.12.5 ([#898](https://github.com/kellnr/kellnr/pull/898))
- *(deps)* bump montudor/action-zip from 0.1.1 to 1.0.0 ([#894](https://github.com/kellnr/kellnr/pull/894))
- *(deps)* bump serde_json from 1.0.146 to 1.0.148 ([#897](https://github.com/kellnr/kellnr/pull/897))
- Merge branch 'main' into dependabot/cargo/main/testcontainers-0.26.3
- Merge branch 'main' into dependabot/cargo/main/axum-extra-0.12.5
- *(deps)* bump actions/checkout from 4 to 6
- *(deps)* bump montudor/action-zip from 0.1.1 to 1.0.0
- *(deps)* bump dependabot/fetch-metadata from 2.3.0 to 2.4.0 ([#895](https://github.com/kellnr/kellnr/pull/895))
- Merge branch 'main' into dependabot/cargo/main/axum-extra-0.12.5
- Merge branch 'main' into dependabot/github_actions/dependabot/fetch-metadata-2.4.0
- improve dependabot auto-merge
- cleanup contribution guide
- *(deps)* bump axum-extra from 0.12.3 to 0.12.5
- *(deps)* bump serde_json from 1.0.146 to 1.0.148
- *(deps)* bump testcontainers from 0.26.2 to 0.26.3
- *(deps)* bump dependabot/fetch-metadata from 2.3.0 to 2.4.0
- Ci/auto merge dependabot ([#892](https://github.com/kellnr/kellnr/pull/892))

This pull request introduces automation for handling Dependabot pull
requests and expands Dependabot's monitoring to include GitHub Actions
workflows. The main changes are the addition of two new GitHub Actions
workflows for auto-approving and auto-merging Dependabot PRs, and
updating the Dependabot configuration to keep GitHub Actions
dependencies up to date.

**Dependabot automation workflows:**

* Added `.github/dependabot-auto-approve.yml` to automatically approve
pull requests opened by Dependabot when they target this repository.
* Added `.github/dependabot-auto-merge.yml` to automatically enable
auto-merge for Dependabot pull requests that update a specific
dependency with a patch version.

**Dependabot configuration updates:**

* Updated `.github/dependabot.yml` to include monitoring and updating of
GitHub Actions workflows on a weekly schedule.

---------

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>
- Devel ([#891](https://github.com/kellnr/kellnr/pull/891))

Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>
- Fix minor typo in config. ([#889](https://github.com/kellnr/kellnr/pull/889))
- Initial Webhook API ([#814](https://github.com/kellnr/kellnr/pull/814)) ([#888](https://github.com/kellnr/kellnr/pull/888))

* Initial Webhook API ([#814](https://github.com/kellnr/kellnr/pull/814))
---------

Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>
- Merge pull request #887 from kellnr/dependabot/cargo/main/moka-0.12.12

build(deps): bump moka from 0.12.11 to 0.12.12
- *(deps)* bump moka from 0.12.11 to 0.12.12
- Merge pull request #884 from kellnr/feature/single-file-binary-881

Feature/single file binary 881
- remove static folder #881
- Merge branch 'feature/single-file-binary-881' of github.com:kellnr/kellnr into feature/single-file-binary-881
- Merge branch 'main' into feature/single-file-binary-881
- Merge pull request #885 from kellnr/fix/clippy-warnings

fix clippy warnings
- clean up
- do not package additional files #881

As kellnr contains the static web resources and a default config,
packaging them into the archive is not needed anymore
- do not require default.toml #811

Use default values from binary instead of file
- include the ui folder in the kellnr binary
- Merge pull request #873 from sfb103/s3-via-serviceacct

feat: remove default S3 access/secret key
- added correct buildier from_env
- updates to all for s3 access via service account
- Merge pull request #876 from kellnr/dependabot/npm_and_yarn/ui/main/types/node-25.0.0

build(deps-dev): bump @types/node from 24.10.3 to 25.0.0 in /ui
- Merge pull request #875 from kellnr/dependabot/cargo/main/reqwest-0.12.25

build(deps): bump reqwest from 0.12.24 to 0.12.25
- Merge pull request #877 from kellnr/dependabot/cargo/main/tower-http-0.6.8

build(deps): bump tower-http from 0.6.7 to 0.6.8
- Merge pull request #878 from kellnr/dependabot/cargo/main/flume-0.12.0

build(deps): bump flume from 0.11.1 to 0.12.0
- *(deps)* bump flume from 0.11.1 to 0.12.0
- *(deps)* bump tower-http from 0.6.7 to 0.6.8
- *(deps-dev)* bump @types/node from 24.10.3 to 25.0.0 in /ui
- *(deps)* bump reqwest from 0.12.24 to 0.12.25
- simplify contributions

Simpler contribution workflow. Instead of using `devel` as an
intermediate branch, use a simple `main` with feature branch approach.
- Merge pull request #862 from s-w2v3/feat-nested_public_url

fix: Kellnr does not work properly if sub-path of a public URL is used
- Merge pull request #874 from kellnr/devel

Devel
- update flake.nix
- Merge pull request #870 from kellnr/dependabot/cargo/devel/tracing-subscriber-0.3.22

build(deps): bump tracing-subscriber from 0.3.20 to 0.3.22
- *(deps)* bump tracing-subscriber from 0.3.20 to 0.3.22
- Merge pull request #867 from kellnr/dependabot/cargo/devel/tracing-0.1.43
- *(deps)* bump tracing from 0.1.41 to 0.1.43
- Merge pull request #868 from kellnr/dependabot/cargo/devel/tower-http-0.6.7
- Merge pull request #869 from kellnr/dependabot/cargo/devel/testcontainers-0.26.0
- *(deps)* bump testcontainers from 0.25.2 to 0.26.0
- *(deps)* bump tower-http from 0.6.6 to 0.6.7
- Merge pull request #863 from kellnr/dependabot/cargo/devel/sea-orm-migration-1.1.19
- Merge pull request #864 from kellnr/dependabot/cargo/devel/axum-extra-0.12.2
- Merge pull request #865 from kellnr/dependabot/cargo/devel/mockall-0.14.0
- Merge pull request #866 from kellnr/dependabot/cargo/devel/syn-2.0.111
- *(deps)* bump syn from 2.0.110 to 2.0.111
- *(deps)* bump mockall from 0.13.1 to 0.14.0
- *(deps)* bump axum-extra from 0.12.1 to 0.12.2
- *(deps)* bump sea-orm-migration from 1.1.17 to 1.1.19
- Fixed application route creation when used sub-path of a URL.
- Syncing with v5.8.0
- Merge pull request #857 from kellnr/dependabot/cargo/devel/hyper-1.8.1
- Merge pull request #858 from kellnr/dependabot/cargo/devel/axum-0.8.7
- Merge pull request #859 from kellnr/dependabot/cargo/devel/bytes-1.11.0
- Merge pull request #860 from kellnr/dependabot/cargo/devel/config-0.15.19
- Merge pull request #861 from kellnr/dependabot/cargo/devel/sea-orm-1.1.19
- *(deps)* bump sea-orm from 1.1.17 to 1.1.19
- *(deps)* bump config from 0.15.18 to 0.15.19
- *(deps)* bump bytes from 1.10.1 to 1.11.0
- *(deps)* bump axum from 0.8.6 to 0.8.7
- *(deps)* bump hyper from 1.7.0 to 1.8.1
- Merge pull request #852 from kellnr/dependabot/cargo/devel/openssl-0.10.75
- Merge pull request #853 from kellnr/dependabot/cargo/devel/syn-2.0.110
- Merge pull request #854 from kellnr/dependabot/cargo/devel/quote-1.0.42
- Merge pull request #855 from kellnr/dependabot/npm_and_yarn/ui/devel/esbuild-0.27.0
- Merge pull request #856 from kellnr/dependabot/npm_and_yarn/ui/devel/marked-17.0.0
- *(deps)* bump marked from 16.4.2 to 17.0.0 in /ui
- *(deps-dev)* bump esbuild from 0.25.12 to 0.27.0 in /ui
- *(deps)* bump quote from 1.0.41 to 1.0.42
- *(deps)* bump syn from 2.0.108 to 2.0.110
- *(deps)* bump openssl from 0.10.74 to 0.10.75
- Merge pull request #851 from kellnr/devel

Pull Request Overview

This PR implements support for running Kellnr on a sub-path of a URL (e.g., https://www.example.com/kellnring/) and updates the UI to use relative paths instead of absolute paths. The key changes enable flexible deployment configurations behind reverse proxies or in subdirectory contexts.

Key changes:

Added path configuration option to the Origin settings for sub-path deployment
Updated UI routing to dynamically calculate base path from current location
Modified API endpoint URLs in the UI to use relative paths (./) instead of absolute paths (/`)
- update node-package.nix
- Merge pull request #815 from hw0lff/url-subpath-support

Add support for running kellnr on a URL subpath
- Merge pull request #849 from kellnr/dependabot/cargo/devel/testcontainers-0.25.2

build(deps): bump testcontainers from 0.25.0 to 0.25.2
- Merge pull request #850 from kellnr/dependabot/cargo/devel/axum-extra-0.12.1

build(deps): bump axum-extra from 0.10.3 to 0.12.1
- *(deps)* bump axum-extra from 0.10.3 to 0.12.1
- *(deps)* bump testcontainers from 0.25.0 to 0.25.2
- Revert "nix based cross compile"

This reverts commit 929c6f26f965678819d905218d7ddc18e0170cc6.
- nix based cross compile
- Merge pull request #848 from kellnr/devel

Pull Request Overview

This PR modernizes the S3 configuration structure by making S3 settings optional and improves various aspects of the codebase including dependency updates, database functionality, and documentation.

Changes S3 settings fields from required strings to optional values for better flexibility
Updates dependencies to newer versions across multiple crates
Fixes database query joins and adds comprehensive tests for crate group user functionality
Adds release documentation and minor code quality improvements
Reviewed Changes
- add release docs
- Merge pull request #844 from kellnr/dependabot/cargo/devel/openssl-0.10.74

build(deps): bump openssl from 0.10.73 to 0.10.74
- Merge pull request #845 from kellnr/dependabot/cargo/devel/syn-2.0.108

build(deps): bump syn from 2.0.107 to 2.0.108
- Merge pull request #846 from kellnr/dependabot/cargo/devel/flate2-1.1.5

build(deps): bump flate2 from 1.1.4 to 1.1.5
- Merge pull request #847 from kellnr/dependabot/cargo/devel/zip-6.0.0

build(deps): bump zip from 5.1.1 to 6.0.0
- Change api_url_path to Option<&str>
- *(deps)* bump zip from 5.1.1 to 6.0.0
- *(deps)* bump flate2 from 1.1.4 to 1.1.5
- *(deps)* bump syn from 2.0.107 to 2.0.108
- *(deps)* bump openssl from 0.10.73 to 0.10.74
- Merge pull request #833 from nyurik/s3-env

feat: allow env-var S3 config
- Merge branch 'main' into s3-env
- revert to S3 Default macro and adjust S3 tests to allow_http
- put custom impl Default back on S3, adding Some() where needed
- Merge pull request #838 from kellnr/dependabot/cargo/devel/reqwest-0.12.24

build(deps): bump reqwest from 0.12.23 to 0.12.24
- Merge branch 'devel' into dependabot/cargo/devel/reqwest-0.12.24
- Merge pull request #839 from kellnr/dependabot/cargo/devel/sea-orm-migration-1.1.17

build(deps): bump sea-orm-migration from 1.1.16 to 1.1.17
- Merge pull request #840 from kellnr/dependabot/cargo/devel/regex-1.12.2

build(deps): bump regex from 1.12.1 to 1.12.2
- Merge pull request #841 from kellnr/dependabot/cargo/devel/syn-2.0.107

build(deps): bump syn from 2.0.106 to 2.0.107
- Merge pull request #842 from kellnr/dependabot/cargo/devel/tokio-1.48.0

build(deps): bump tokio from 1.47.1 to 1.48.0
- *(deps)* bump tokio from 1.47.1 to 1.48.0
- *(deps)* bump syn from 2.0.106 to 2.0.107
- *(deps)* bump regex from 1.12.1 to 1.12.2
- *(deps)* bump sea-orm-migration from 1.1.16 to 1.1.17
- *(deps)* bump reqwest from 0.12.23 to 0.12.24
- Merge pull request #834 from kellnr/dependabot/cargo/devel/regex-1.12.1

build(deps): bump regex from 1.11.3 to 1.12.1
- Merge pull request #835 from kellnr/dependabot/cargo/devel/axum-extra-0.10.3

build(deps): bump axum-extra from 0.10.1 to 0.10.3
- Merge pull request #836 from kellnr/dependabot/cargo/devel/sea-orm-1.1.17

build(deps): bump sea-orm from 1.1.16 to 1.1.17
- Merge pull request #837 from kellnr/dependabot/cargo/devel/toml-0.9.8

build(deps): bump toml from 0.9.7 to 0.9.8
- *(deps)* bump toml from 0.9.7 to 0.9.8
- *(deps)* bump sea-orm from 1.1.16 to 1.1.17
- *(deps)* bump axum-extra from 0.10.1 to 0.10.3
- *(deps)* bump regex from 1.11.3 to 1.12.1
- Merge pull request #830 from kellnr/dependabot/cargo/devel/thiserror-2.0.17
- Merge pull request #829 from kellnr/dependabot/cargo/devel/config-0.15.18
- Merge pull request #828 from kellnr/dependabot/cargo/devel/flate2-1.1.4
- Merge pull request #827 from kellnr/dependabot/cargo/devel/axum-0.8.6
- *(deps)* bump thiserror from 2.0.16 to 2.0.17
- Merge pull request #826 from kellnr/dependabot/cargo/devel/moka-0.12.11
- *(deps)* bump config from 0.15.17 to 0.15.18
- *(deps)* bump flate2 from 1.1.2 to 1.1.4
- *(deps)* bump axum from 0.8.4 to 0.8.6
- *(deps)* bump moka from 0.12.10 to 0.12.11
- Merge pull request #824 from hw0lff/fix-crate-group-user-query

Fix crate group user query
- Add origin.path setting in StartupConfig component
- Remove obsolete comment
- Fix query with multiple inner joins in is_crate_group_user
- Add test for is_crate_group_user
- Always serve at URL root
- Fix broken cratesio proxying
- Add support for running kellnr on a URL subpath
- Merge pull request #822 from kellnr/dependabot/cargo/devel/object_store-0.12.4
- *(deps)* bump object_store from 0.12.3 to 0.12.4
- Merge pull request #819 from kellnr/dependabot/cargo/devel/regex-1.11.3
- Merge pull request #820 from kellnr/dependabot/cargo/devel/serde-1.0.228
- Merge pull request #821 from kellnr/dependabot/cargo/devel/config-0.15.17
- Merge pull request #823 from kellnr/dependabot/cargo/devel/quote-1.0.41
- *(deps)* bump quote from 1.0.40 to 1.0.41
- *(deps)* bump config from 0.15.16 to 0.15.17
- *(deps)* bump serde from 1.0.226 to 1.0.228
- *(deps)* bump regex from 1.11.2 to 1.11.3
- Merge pull request #810 from kellnr/dependabot/cargo/devel/serde-1.0.226

build(deps): bump serde from 1.0.224 to 1.0.226
- Merge pull request #811 from kellnr/dependabot/cargo/devel/config-0.15.16

build(deps): bump config from 0.15.15 to 0.15.16
- Merge pull request #812 from kellnr/dependabot/cargo/devel/toml-0.9.6

build(deps): bump toml from 0.9.5 to 0.9.6
- Merge pull request #813 from kellnr/dependabot/cargo/devel/time-0.3.44

build(deps): bump time from 0.3.43 to 0.3.44
- *(deps)* bump time from 0.3.43 to 0.3.44
- *(deps)* bump toml from 0.9.5 to 0.9.6
- *(deps)* bump config from 0.15.15 to 0.15.16
- *(deps)* bump serde from 1.0.224 to 1.0.226
- allow dead code in migrations
- Merge pull request #809 from kellnr/devel

Devel
- Merge pull request #807 from kellnr/devel

Devel
- Merge branch 'devel' of github.com:kellnr/kellnr into devel
- Merge pull request #804 from kellnr/dependabot/cargo/devel/serde-1.0.223
- *(deps)* bump serde from 1.0.219 to 1.0.223
- Merge pull request #803 from kellnr/dependabot/cargo/devel/zip-5.1.1
- Merge pull request #805 from kellnr/dependabot/cargo/devel/semver-1.0.27
- Merge pull request #806 from kellnr/dependabot/cargo/devel/serde_json-1.0.145
- *(deps)* bump serde_json from 1.0.143 to 1.0.145
- *(deps)* bump semver from 1.0.26 to 1.0.27
- *(deps)* bump zip from 5.1.0 to 5.1.1
- update flake.nix
- consitent color
- improve CSS
- remove unecessary information

Remove the "Updated" information in the "About" page of a crate
- Merge pull request #800 from fellhorn/dennis/feat/cratesio-indices

Feat: Add cratesio indices

Thanks for the PR!
- Merge pull request #801 from kellnr/dep-experiments

update dependencies
- update dependencies
- Add cratesio indices
- add docs for minimal docker image
- Merge pull request #799 from kellnr/devel

fix script
- Merge pull request #798 from kellnr/devel

Devel
- Merge pull request #797 from kellnr/minimal-docker-image

add minimal Dockerfile #792
- add minimal Dockerfile #792
- Merge pull request #796 from nyurik/bump-deps

chore: default just, update deps
- Merge pull request #793 from kellnr/dependabot/cargo/devel/sea-orm-migration-1.1.15

build(deps): bump sea-orm-migration from 1.1.14 to 1.1.15
- default just, update deps
- Merge pull request #794 from kellnr/dependabot/cargo/devel/time-0.3.43

build(deps): bump time from 0.3.42 to 0.3.43
- Merge pull request #795 from kellnr/dependabot/cargo/devel/zip-4.6.1

build(deps): bump zip from 4.6.0 to 4.6.1
- *(deps)* bump zip from 4.6.0 to 4.6.1
- *(deps)* bump time from 0.3.42 to 0.3.43
- *(deps)* bump sea-orm-migration from 1.1.14 to 1.1.15
- Merge pull request #789 from kellnr/dependabot/cargo/devel/zip-4.6.0
- *(deps)* bump zip from 4.5.0 to 4.6.0
- Merge pull request #787 from kellnr/dependabot/cargo/devel/config-0.15.15
- Merge pull request #788 from kellnr/dependabot/cargo/devel/time-0.3.42
- Merge pull request #790 from kellnr/dependabot/cargo/devel/sea-orm-1.1.15
- *(deps)* bump sea-orm from 1.1.14 to 1.1.15
- *(deps)* bump time from 0.3.41 to 0.3.42
- *(deps)* bump config from 0.15.14 to 0.15.15
- update node version
- Merge pull request #785 from kellnr/devel

Devel
- Merge branch 'main' into devel
- Merge pull request #773 from FlorentinDUBOIS/main

feat(crates/auth): handle bearer token and basic authentication
- Merge pull request #784 from kellnr/dependabot/cargo/tracing-subscriber-0.3.20
- *(deps)* bump tracing-subscriber from 0.3.19 to 0.3.20
- do not ignore target/ in .dockerignore
- update package.json
- Merge pull request #782 from kellnr/dependabot/cargo/devel/regex-1.11.2

build(deps): bump regex from 1.11.1 to 1.11.2
- Merge pull request #781 from kellnr/dependabot/cargo/devel/async-std-1.13.2

build(deps): bump async-std from 1.13.1 to 1.13.2
- Merge pull request #780 from kellnr/dependabot/cargo/devel/async-trait-0.1.89

build(deps): bump async-trait from 0.1.88 to 0.1.89
- Merge pull request #779 from kellnr/dependabot/cargo/devel/hyper-1.7.0

build(deps): bump hyper from 1.6.0 to 1.7.0
- *(deps)* bump regex from 1.11.1 to 1.11.2
- Merge pull request #783 from kellnr/dependabot/cargo/devel/zip-4.5.0

build(deps): bump zip from 4.3.0 to 4.5.0
- *(deps)* bump zip from 4.3.0 to 4.5.0
- *(deps)* bump async-std from 1.13.1 to 1.13.2
- *(deps)* bump async-trait from 0.1.88 to 0.1.89
- *(deps)* bump hyper from 1.6.0 to 1.7.0
- Merge pull request #778 from kellnr/dependabot/cargo/devel/serde_json-1.0.143

build(deps): bump serde_json from 1.0.142 to 1.0.143
- Merge pull request #774 from kellnr/dependabot/npm_and_yarn/ui/devel/vue/tsconfig-0.8.1

build(deps-dev): bump @vue/tsconfig from 0.7.0 to 0.8.1 in /ui
- Merge pull request #776 from kellnr/dependabot/cargo/devel/syn-2.0.106

build(deps): bump syn from 2.0.104 to 2.0.106
- Merge pull request #775 from kellnr/dependabot/cargo/devel/reqwest-0.12.23

build(deps): bump reqwest from 0.12.22 to 0.12.23
- *(deps)* bump serde_json from 1.0.142 to 1.0.143
- *(deps)* bump syn from 2.0.104 to 2.0.106
- *(deps)* bump reqwest from 0.12.22 to 0.12.23
- *(deps-dev)* bump @vue/tsconfig from 0.7.0 to 0.8.1 in /ui
- add download_on_update flag to UI #760
- prefetch crates from crates.io #760

If enabled, download crates from crates.io if a new version if found
during the prefetch of the index data. #760
- update flake.nix
- update cert
- use only one database connection pool
- Merge pull request #770 from kellnr/main

Update deps
- Merge branch 'devel' into main
- *(deps)* bump sea-query from 0.32.6 to 0.32.7
- *(deps)* bump toml from 0.9.4 to 0.9.5
- *(deps-dev)* bump typescript from 5.8.3 to 5.9.2 in /ui
- *(deps)* bump tokio from 1.47.0 to 1.47.1
- *(deps)* bump sea-orm-migration from 1.1.13 to 1.1.14
- *(deps)* bump toml from 0.9.2 to 0.9.4
- *(deps)* bump serde_json from 1.0.141 to 1.0.142
- *(deps)* bump sea-orm from 1.1.13 to 1.1.14
- *(deps)* bump tokio from 1.46.1 to 1.47.0
- *(deps)* bump rand from 0.9.1 to 0.9.2
- *(deps)* bump serde_json from 1.0.140 to 1.0.141
- *(deps)* bump object_store from 0.12.2 to 0.12.3
- *(deps)* bump toml from 0.8.23 to 0.9.2
- *(deps)* bump config from 0.15.11 to 0.15.13
- *(deps)* bump zip from 4.2.0 to 4.3.0
- *(deps)* bump sea-orm-migration from 1.1.12 to 1.1.13
- *(deps)* bump tokio from 1.45.1 to 1.46.1
- *(deps)* bump reqwest from 0.12.20 to 0.12.22
- *(deps-dev)* bump vue-tsc from 2.2.12 to 3.0.1 in /ui
- *(deps-dev)* bump vite from 6.3.5 to 7.0.0 in /ui
- *(deps)* bump sea-orm from 1.1.12 to 1.1.13
- *(deps)* bump marked from 15.0.12 to 16.0.0 in /ui
- *(deps-dev)* bump @vitejs/plugin-vue from 5.2.4 to 6.0.0 in /ui
- *(deps)* bump zip from 4.1.0 to 4.2.0
- *(deps)* bump syn from 2.0.103 to 2.0.104
- Update Cargo.lock
- *(deps)* bump rand from 0.9.1 to 0.9.2
- *(deps)* bump serde_json from 1.0.140 to 1.0.141
- *(deps)* bump object_store from 0.12.2 to 0.12.3
- *(deps)* bump toml from 0.8.23 to 0.9.2
- *(deps)* bump config from 0.15.11 to 0.15.13
- *(deps)* bump zip from 4.2.0 to 4.3.0
- *(deps)* bump sea-orm-migration from 1.1.12 to 1.1.13
- *(deps)* bump tokio from 1.45.1 to 1.46.1
- *(deps)* bump reqwest from 0.12.20 to 0.12.22
- *(deps-dev)* bump vue-tsc from 2.2.12 to 3.0.1 in /ui
- *(deps-dev)* bump vite from 6.3.5 to 7.0.0 in /ui
- *(deps)* bump sea-orm from 1.1.12 to 1.1.13
- *(deps)* bump marked from 15.0.12 to 16.0.0 in /ui
- *(deps-dev)* bump @vitejs/plugin-vue from 5.2.4 to 6.0.0 in /ui
- *(deps)* bump zip from 4.1.0 to 4.2.0
- *(deps)* bump syn from 2.0.103 to 2.0.104
- Update Cargo.lock
- Merge branch 'main' of github.com:kellnr/kellnr into devel

# Conflicts:
#	Cargo.lock
#	Cargo.toml
- Merge branch 'devel' of github.com:kellnr/kellnr into devel
- *(deps-dev)* bump @types/node from 22.15.32 to 24.0.2 in /ui
- *(deps)* bump zip from 4.0.0 to 4.1.0
- *(deps)* bump object_store from 0.12.1 to 0.12.2
- *(deps)* bump reqwest from 0.12.19 to 0.12.20
- *(deps-dev)* bump @types/node from 22.15.32 to 24.0.2 in /ui
- *(deps)* bump syn from 2.0.101 to 2.0.103
- Merge branch 'devel' of github.com:kellnr/kellnr into devel
- fix `unused_async` ([#730](https://github.com/kellnr/kellnr/pull/730))
- use explicit type for defaults ([#729](https://github.com/kellnr/kellnr/pull/729))
- optimize dependencies ([#728](https://github.com/kellnr/kellnr/pull/728))
- lots of simple lint cleanup ([#721](https://github.com/kellnr/kellnr/pull/721))
- cleanup use wildcards ([#722](https://github.com/kellnr/kellnr/pull/722))
- fix single_match_else ([#726](https://github.com/kellnr/kellnr/pull/726))
- fix implicit_clone ([#727](https://github.com/kellnr/kellnr/pull/727))
- *(deps)* bump tower-http from 0.6.5 to 0.6.6 ([#715](https://github.com/kellnr/kellnr/pull/715))
- *(deps)* bump flate2 from 1.1.1 to 1.1.2 ([#716](https://github.com/kellnr/kellnr/pull/716))
- *(deps)* bump toml from 0.8.22 to 0.8.23 ([#717](https://github.com/kellnr/kellnr/pull/717))
- *(deps)* bump reqwest from 0.12.18 to 0.12.19 ([#718](https://github.com/kellnr/kellnr/pull/718))
- *(deps)* bump minio-rsc from 0.2.5 to 0.2.6 ([#719](https://github.com/kellnr/kellnr/pull/719))
- fix redundant closures ([#724](https://github.com/kellnr/kellnr/pull/724))
- clean up some string code ([#723](https://github.com/kellnr/kellnr/pull/723))
- Merge branch 'devel' of github.com:kellnr/kellnr into devel
- inline format args ([#720](https://github.com/kellnr/kellnr/pull/720))
- cargo fmt
- add workspace-based linting ([#714](https://github.com/kellnr/kellnr/pull/714))
- *(deps)* bump tower-http from 0.6.4 to 0.6.5 ([#711](https://github.com/kellnr/kellnr/pull/711))
- Devel ([#710](https://github.com/kellnr/kellnr/pull/710))

* manual merge of #675

First part for hardening the indices

* refactor routing into own module

* refactor

* Use transaction for complex db inserts ([#679](https://github.com/kellnr/kellnr/pull/679))

* initial db refactor

* fix postgres tests

* use txn for cratesio update

* sqlite transaction tests

* postgres transaction tests

* db test cleanup

* formatting

* build(deps): bump toml from 0.8.20 to 0.8.21 ([#686](https://github.com/kellnr/kellnr/pull/686))

* build(deps): bump syn from 2.0.100 to 2.0.101 ([#685](https://github.com/kellnr/kellnr/pull/685))

* build(deps): bump chrono from 0.4.40 to 0.4.41 ([#689](https://github.com/kellnr/kellnr/pull/689))

* build(deps): bump axum from 0.8.3 to 0.8.4 ([#688](https://github.com/kellnr/kellnr/pull/688))

* build(deps): bump toml from 0.8.21 to 0.8.22 ([#687](https://github.com/kellnr/kellnr/pull/687))

* build(deps): bump tokio from 1.44.2 to 1.45.0 ([#694](https://github.com/kellnr/kellnr/pull/694))

* build(deps): bump sea-query from 0.32.4 to 0.32.5 ([#693](https://github.com/kellnr/kellnr/pull/693))

* build(deps): bump tower-http from 0.6.2 to 0.6.4 ([#692](https://github.com/kellnr/kellnr/pull/692))

* build(deps): bump sea-orm from 1.1.10 to 1.1.11 ([#691](https://github.com/kellnr/kellnr/pull/691))

* build(deps): bump minio-rsc from 0.2.3 to 0.2.5 ([#698](https://github.com/kellnr/kellnr/pull/698))

Bumps minio-rsc from 0.2.3 to 0.2.5.

---
updated-dependencies:
- dependency-name: minio-rsc
  dependency-version: 0.2.5
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump sea-orm-migration from 1.1.10 to 1.1.11 ([#697](https://github.com/kellnr/kellnr/pull/697))

Bumps [sea-orm-migration](https://github.com/SeaQL/sea-orm) from 1.1.10 to 1.1.11.
- [Release notes](https://github.com/SeaQL/sea-orm/releases)
- [Changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/SeaQL/sea-orm/compare/1.1.10...1.1.11)

---
updated-dependencies:
- dependency-name: sea-orm-migration
  dependency-version: 1.1.11
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump object_store from 0.12.0 to 0.12.1 ([#696](https://github.com/kellnr/kellnr/pull/696))

Bumps [object_store](https://github.com/apache/arrow-rs-object-store) from 0.12.0 to 0.12.1.
- [Changelog](https://github.com/apache/arrow-rs-object-store/blob/main/CHANGELOG-old.md)
- [Commits](https://github.com/apache/arrow-rs-object-store/compare/v0.12.0...v0.12.1)

---
updated-dependencies:
- dependency-name: object_store
  dependency-version: 0.12.1
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Optionally limit new crate publishing by non-admin users. ([#671](https://github.com/kellnr/kellnr/pull/671))

* restrict new crate publishing

* initial add_empty_crate

* payload fix

* empty crate tests

* conflicts

* post rebase update

* fix warnings

fix warnings

* improve flake.nix

* improve cross-compilation in flake.nix

* flake.nix build on nixos

* improve flake.nix

* initial lock fix ([#704](https://github.com/kellnr/kellnr/pull/704))

* Improved testing ([#707](https://github.com/kellnr/kellnr/pull/707))


---------

Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>

* fix latest release in smoke test

* update deps

* remove "v" from version number

* update Cargo.lock

* fix typo

* fix ci

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
- Devel ([#709](https://github.com/kellnr/kellnr/pull/709))

* manual merge of #675

First part for hardening the indices

* refactor routing into own module

* refactor

* Use transaction for complex db inserts ([#679](https://github.com/kellnr/kellnr/pull/679))

* initial db refactor

* fix postgres tests

* use txn for cratesio update

* sqlite transaction tests

* postgres transaction tests

* db test cleanup

* formatting

* build(deps): bump toml from 0.8.20 to 0.8.21 ([#686](https://github.com/kellnr/kellnr/pull/686))

* build(deps): bump syn from 2.0.100 to 2.0.101 ([#685](https://github.com/kellnr/kellnr/pull/685))

* build(deps): bump chrono from 0.4.40 to 0.4.41 ([#689](https://github.com/kellnr/kellnr/pull/689))

* build(deps): bump axum from 0.8.3 to 0.8.4 ([#688](https://github.com/kellnr/kellnr/pull/688))

* build(deps): bump toml from 0.8.21 to 0.8.22 ([#687](https://github.com/kellnr/kellnr/pull/687))

* build(deps): bump tokio from 1.44.2 to 1.45.0 ([#694](https://github.com/kellnr/kellnr/pull/694))

* build(deps): bump sea-query from 0.32.4 to 0.32.5 ([#693](https://github.com/kellnr/kellnr/pull/693))

* build(deps): bump tower-http from 0.6.2 to 0.6.4 ([#692](https://github.com/kellnr/kellnr/pull/692))

* build(deps): bump sea-orm from 1.1.10 to 1.1.11 ([#691](https://github.com/kellnr/kellnr/pull/691))

* build(deps): bump minio-rsc from 0.2.3 to 0.2.5 ([#698](https://github.com/kellnr/kellnr/pull/698))

Bumps minio-rsc from 0.2.3 to 0.2.5.

---
updated-dependencies:
- dependency-name: minio-rsc
  dependency-version: 0.2.5
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump sea-orm-migration from 1.1.10 to 1.1.11 ([#697](https://github.com/kellnr/kellnr/pull/697))

Bumps [sea-orm-migration](https://github.com/SeaQL/sea-orm) from 1.1.10 to 1.1.11.
- [Release notes](https://github.com/SeaQL/sea-orm/releases)
- [Changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/SeaQL/sea-orm/compare/1.1.10...1.1.11)

---
updated-dependencies:
- dependency-name: sea-orm-migration
  dependency-version: 1.1.11
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump object_store from 0.12.0 to 0.12.1 ([#696](https://github.com/kellnr/kellnr/pull/696))

Bumps [object_store](https://github.com/apache/arrow-rs-object-store) from 0.12.0 to 0.12.1.
- [Changelog](https://github.com/apache/arrow-rs-object-store/blob/main/CHANGELOG-old.md)
- [Commits](https://github.com/apache/arrow-rs-object-store/compare/v0.12.0...v0.12.1)

---
updated-dependencies:
- dependency-name: object_store
  dependency-version: 0.12.1
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Optionally limit new crate publishing by non-admin users. ([#671](https://github.com/kellnr/kellnr/pull/671))

* restrict new crate publishing

* initial add_empty_crate

* payload fix

* empty crate tests

* conflicts

* post rebase update

* fix warnings

fix warnings

* improve flake.nix

* improve cross-compilation in flake.nix

* flake.nix build on nixos

* improve flake.nix

* initial lock fix ([#704](https://github.com/kellnr/kellnr/pull/704))

* Improved testing ([#707](https://github.com/kellnr/kellnr/pull/707))


---------

Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>

* fix latest release in smoke test

* update deps

* remove "v" from version number

* update Cargo.lock

* fix typo

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
- update Cargo.lock
- remove "v" from version number
- Merge branch 'main' into devel
- update deps
- Devel ([#708](https://github.com/kellnr/kellnr/pull/708))

* manual merge of #675

First part for hardening the indices

* refactor routing into own module

* refactor

* Use transaction for complex db inserts ([#679](https://github.com/kellnr/kellnr/pull/679))

* initial db refactor

* fix postgres tests

* use txn for cratesio update

* sqlite transaction tests

* postgres transaction tests

* db test cleanup

* formatting

* build(deps): bump toml from 0.8.20 to 0.8.21 ([#686](https://github.com/kellnr/kellnr/pull/686))

* build(deps): bump syn from 2.0.100 to 2.0.101 ([#685](https://github.com/kellnr/kellnr/pull/685))

* build(deps): bump chrono from 0.4.40 to 0.4.41 ([#689](https://github.com/kellnr/kellnr/pull/689))

* build(deps): bump axum from 0.8.3 to 0.8.4 ([#688](https://github.com/kellnr/kellnr/pull/688))

* build(deps): bump toml from 0.8.21 to 0.8.22 ([#687](https://github.com/kellnr/kellnr/pull/687))

* build(deps): bump tokio from 1.44.2 to 1.45.0 ([#694](https://github.com/kellnr/kellnr/pull/694))

* build(deps): bump sea-query from 0.32.4 to 0.32.5 ([#693](https://github.com/kellnr/kellnr/pull/693))

* build(deps): bump tower-http from 0.6.2 to 0.6.4 ([#692](https://github.com/kellnr/kellnr/pull/692))

* build(deps): bump sea-orm from 1.1.10 to 1.1.11 ([#691](https://github.com/kellnr/kellnr/pull/691))

* build(deps): bump minio-rsc from 0.2.3 to 0.2.5 ([#698](https://github.com/kellnr/kellnr/pull/698))

Bumps minio-rsc from 0.2.3 to 0.2.5.

---
updated-dependencies:
- dependency-name: minio-rsc
  dependency-version: 0.2.5
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump sea-orm-migration from 1.1.10 to 1.1.11 ([#697](https://github.com/kellnr/kellnr/pull/697))

Bumps [sea-orm-migration](https://github.com/SeaQL/sea-orm) from 1.1.10 to 1.1.11.
- [Release notes](https://github.com/SeaQL/sea-orm/releases)
- [Changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/SeaQL/sea-orm/compare/1.1.10...1.1.11)

---
updated-dependencies:
- dependency-name: sea-orm-migration
  dependency-version: 1.1.11
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump object_store from 0.12.0 to 0.12.1 ([#696](https://github.com/kellnr/kellnr/pull/696))

Bumps [object_store](https://github.com/apache/arrow-rs-object-store) from 0.12.0 to 0.12.1.
- [Changelog](https://github.com/apache/arrow-rs-object-store/blob/main/CHANGELOG-old.md)
- [Commits](https://github.com/apache/arrow-rs-object-store/compare/v0.12.0...v0.12.1)

---
updated-dependencies:
- dependency-name: object_store
  dependency-version: 0.12.1
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Optionally limit new crate publishing by non-admin users. ([#671](https://github.com/kellnr/kellnr/pull/671))

* restrict new crate publishing

* initial add_empty_crate

* payload fix

* empty crate tests

* conflicts

* post rebase update

* fix warnings

fix warnings

* improve flake.nix

* improve cross-compilation in flake.nix

* flake.nix build on nixos

* improve flake.nix

* initial lock fix ([#704](https://github.com/kellnr/kellnr/pull/704))

* Improved testing ([#707](https://github.com/kellnr/kellnr/pull/707))


---------

Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
- Improved testing ([#707](https://github.com/kellnr/kellnr/pull/707))


---------

Co-authored-by: Maciej Główka <maciek.glowka@gmail.com>
- initial lock fix ([#704](https://github.com/kellnr/kellnr/pull/704))
- improve flake.nix
- flake.nix build on nixos
- improve cross-compilation in flake.nix
- improve flake.nix
- Optionally limit new crate publishing by non-admin users. ([#671](https://github.com/kellnr/kellnr/pull/671))

* restrict new crate publishing

* initial add_empty_crate

* payload fix

* empty crate tests

* conflicts

* post rebase update
- *(deps)* bump object_store from 0.12.0 to 0.12.1 ([#696](https://github.com/kellnr/kellnr/pull/696))
- *(deps)* bump sea-orm-migration from 1.1.10 to 1.1.11 ([#697](https://github.com/kellnr/kellnr/pull/697))
- *(deps)* bump minio-rsc from 0.2.3 to 0.2.5 ([#698](https://github.com/kellnr/kellnr/pull/698))
- *(deps)* bump sea-orm from 1.1.10 to 1.1.11 ([#691](https://github.com/kellnr/kellnr/pull/691))
- *(deps)* bump tower-http from 0.6.2 to 0.6.4 ([#692](https://github.com/kellnr/kellnr/pull/692))
- *(deps)* bump sea-query from 0.32.4 to 0.32.5 ([#693](https://github.com/kellnr/kellnr/pull/693))
- *(deps)* bump tokio from 1.44.2 to 1.45.0 ([#694](https://github.com/kellnr/kellnr/pull/694))
- *(deps)* bump toml from 0.8.21 to 0.8.22 ([#687](https://github.com/kellnr/kellnr/pull/687))
- *(deps)* bump axum from 0.8.3 to 0.8.4 ([#688](https://github.com/kellnr/kellnr/pull/688))
- *(deps)* bump chrono from 0.4.40 to 0.4.41 ([#689](https://github.com/kellnr/kellnr/pull/689))
- *(deps)* bump syn from 2.0.100 to 2.0.101 ([#685](https://github.com/kellnr/kellnr/pull/685))
- *(deps)* bump toml from 0.8.20 to 0.8.21 ([#686](https://github.com/kellnr/kellnr/pull/686))
- Use transaction for complex db inserts ([#679](https://github.com/kellnr/kellnr/pull/679))

* initial db refactor

* fix postgres tests

* use txn for cratesio update

* sqlite transaction tests

* postgres transaction tests

* db test cleanup

* formatting
- refactor
- refactor routing into own module
- manual merge of #675

First part for hardening the indices
- Contributing.md ([#684](https://github.com/kellnr/kellnr/pull/684))

Add CONTRIBUTING.md file
- New web interface ([#682](https://github.com/kellnr/kellnr/pull/682))

- New web UI with better design and responsiveness
- Store hash of API tokens in database
- Fix #670 ([#673](https://github.com/kellnr/kellnr/pull/673))

* Main ([#660](https://github.com/kellnr/kellnr/pull/660))

* Devel ([#553](https://github.com/kellnr/kellnr/pull/553))

* Feature #209: initial implementation of download authorization

* update npm packages

* fix missing crate description

* remove debug prints

* fix padding in readme rendering

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>

* check emty username and password ([#573](https://github.com/kellnr/kellnr/pull/573))

* add enpoint to get all crate versions ([#576](https://github.com/kellnr/kellnr/pull/576))

* Devel ([#585](https://github.com/kellnr/kellnr/pull/585))

* Feature #209: initial implementation of download authorization

* update npm packages

* fix missing crate description

* remove debug prints

* fix padding in readme rendering

* build(deps-dev): bump vite from 6.0.5 to 6.0.6 in /ui ([#560](https://github.com/kellnr/kellnr/pull/560))

* build(deps): bump reqwest from 0.12.9 to 0.12.11 ([#559](https://github.com/kellnr/kellnr/pull/559))

* build(deps): bump quote from 1.0.37 to 1.0.38 ([#558](https://github.com/kellnr/kellnr/pull/558))

* build(deps): bump anyhow from 1.0.94 to 1.0.95 ([#557](https://github.com/kellnr/kellnr/pull/557))

* build(deps): bump serde_json from 1.0.133 to 1.0.134 ([#555](https://github.com/kellnr/kellnr/pull/555))

* build(deps): bump serde from 1.0.216 to 1.0.217 ([#556](https://github.com/kellnr/kellnr/pull/556))

Bumps [serde](https://github.com/serde-rs/serde) from 1.0.216 to 1.0.217.
- [Release notes](https://github.com/serde-rs/serde/releases)
- [Commits](https://github.com/serde-rs/serde/compare/v1.0.216...v1.0.217)

---
updated-dependencies:
- dependency-name: serde
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps-dev): bump vite from 6.0.6 to 6.0.7 in /ui ([#566](https://github.com/kellnr/kellnr/pull/566))

* build(deps): bump hyper from 1.5.1 to 1.5.2 ([#565](https://github.com/kellnr/kellnr/pull/565))

* build(deps): bump sea-orm from 1.1.1 to 1.1.3 ([#564](https://github.com/kellnr/kellnr/pull/564))

* build(deps): bump syn from 2.0.93 to 2.0.95 ([#563](https://github.com/kellnr/kellnr/pull/563))

* build(deps): bump reqwest from 0.12.11 to 0.12.12 ([#562](https://github.com/kellnr/kellnr/pull/562))

* build(deps): bump moka from 0.12.8 to 0.12.10 ([#561](https://github.com/kellnr/kellnr/pull/561))

* build(deps): bump sea-orm from 1.1.3 to 1.1.4 ([#571](https://github.com/kellnr/kellnr/pull/571))

Bumps [sea-orm](https://github.com/SeaQL/sea-orm) from 1.1.3 to 1.1.4.
- [Release notes](https://github.com/SeaQL/sea-orm/releases)
- [Changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/SeaQL/sea-orm/compare/1.1.3...1.1.4)

---
updated-dependencies:
- dependency-name: sea-orm
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump proc-macro2 from 1.0.92 to 1.0.93 ([#570](https://github.com/kellnr/kellnr/pull/570))

Bumps [proc-macro2](https://github.com/dtolnay/proc-macro2) from 1.0.92 to 1.0.93.
- [Release notes](https://github.com/dtolnay/proc-macro2/releases)
- [Commits](https://github.com/dtolnay/proc-macro2/compare/1.0.92...1.0.93)

---
updated-dependencies:
- dependency-name: proc-macro2
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump serde_json from 1.0.134 to 1.0.135 ([#569](https://github.com/kellnr/kellnr/pull/569))

Bumps [serde_json](https://github.com/serde-rs/json) from 1.0.134 to 1.0.135.
- [Release notes](https://github.com/serde-rs/json/releases)
- [Commits](https://github.com/serde-rs/json/compare/v1.0.134...v1.0.135)

---
updated-dependencies:
- dependency-name: serde_json
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump sea-orm-migration from 1.1.1 to 1.1.3 ([#568](https://github.com/kellnr/kellnr/pull/568))

Bumps [sea-orm-migration](https://github.com/SeaQL/sea-orm) from 1.1.1 to 1.1.3.
- [Release notes](https://github.com/SeaQL/sea-orm/releases)
- [Changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/SeaQL/sea-orm/compare/1.1.1...1.1.3)

---
updated-dependencies:
- dependency-name: sea-orm-migration
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump sea-orm-migration from 1.1.3 to 1.1.4 ([#574](https://github.com/kellnr/kellnr/pull/574))

Bumps [sea-orm-migration](https://github.com/SeaQL/sea-orm) from 1.1.3 to 1.1.4.
- [Release notes](https://github.com/SeaQL/sea-orm/releases)
- [Changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/SeaQL/sea-orm/compare/1.1.3...1.1.4)

---
updated-dependencies:
- dependency-name: sea-orm-migration
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump syn from 2.0.95 to 2.0.96 ([#567](https://github.com/kellnr/kellnr/pull/567))

Bumps [syn](https://github.com/dtolnay/syn) from 2.0.95 to 2.0.96.
- [Release notes](https://github.com/dtolnay/syn/releases)
- [Commits](https://github.com/dtolnay/syn/compare/2.0.95...2.0.96)

---
updated-dependencies:
- dependency-name: syn
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Main ([#575](https://github.com/kellnr/kellnr/pull/575))

* Devel ([#553](https://github.com/kellnr/kellnr/pull/553))

* Feature #209: initial implementation of download authorization

* update npm packages

* fix missing crate description

* remove debug prints

* fix padding in readme rendering

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>

* check emty username and password ([#573](https://github.com/kellnr/kellnr/pull/573))

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>
Co-authored-by: badsmoke <github@badcloud.eu>

* Main ([#577](https://github.com/kellnr/kellnr/pull/577))

* Devel ([#553](https://github.com/kellnr/kellnr/pull/553))

* Feature #209: initial implementation of download authorization

* update npm packages

* fix missing crate description

* remove debug prints

* fix padding in readme rendering

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>

* check emty username and password ([#573](https://github.com/kellnr/kellnr/pull/573))

* add enpoint to get all crate versions ([#576](https://github.com/kellnr/kellnr/pull/576))

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>
Co-authored-by: badsmoke <github@badcloud.eu>
Co-authored-by: Carl Scherer <carl.scherer@kenbun.de>

* update flake.lock

* build(deps): bump semver from 1.0.24 to 1.0.25 ([#582](https://github.com/kellnr/kellnr/pull/582))

* build(deps): bump tokio from 1.42.0 to 1.43.0 ([#581](https://github.com/kellnr/kellnr/pull/581))

* build(deps): bump serde_json from 1.0.135 to 1.0.137 ([#580](https://github.com/kellnr/kellnr/pull/580))

* build(deps): bump thiserror from 2.0.9 to 2.0.11 ([#579](https://github.com/kellnr/kellnr/pull/579))

* build(deps-dev): bump vite from 6.0.7 to 6.0.8 in /ui ([#578](https://github.com/kellnr/kellnr/pull/578))

* fix #583

* Main ([#584](https://github.com/kellnr/kellnr/pull/584))

* Devel ([#553](https://github.com/kellnr/kellnr/pull/553))

* Feature #209: initial implementation of download authorization

* update npm packages

* fix missing crate description

* remove debug prints

* fix padding in readme rendering

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>

* check emty username and password ([#573](https://github.com/kellnr/kellnr/pull/573))

* add enpoint to get all crate versions ([#576](https://github.com/kellnr/kellnr/pull/576))

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>
Co-authored-by: badsmoke <github@badcloud.eu>
Co-authored-by: Carl Scherer <carl.scherer@kenbun.de>

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: badsmoke <github@badcloud.eu>
Co-authored-by: Carl Scherer <carl.scherer@kenbun.de>

* build(deps): bump openssl from 0.10.68 to 0.10.70 ([#597](https://github.com/kellnr/kellnr/pull/597))

Bumps [openssl](https://github.com/sfackler/rust-openssl) from 0.10.68 to 0.10.70.
- [Release notes](https://github.com/sfackler/rust-openssl/releases)
- [Commits](https://github.com/sfackler/rust-openssl/compare/openssl-v0.10.68...openssl-v0.10.70)

---
updated-dependencies:
- dependency-name: openssl
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump ring from 0.17.8 to 0.17.13 ([#633](https://github.com/kellnr/kellnr/pull/633))

* build(deps): bump zip from 2.2.2 to 2.4.1 ([#648](https://github.com/kellnr/kellnr/pull/648))

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>
Co-authored-by: badsmoke <github@badcloud.eu>
Co-authored-by: Carl Scherer <carl.scherer@kenbun.de>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* fix after merge

* fix again

* Implement User Groups ([#649](https://github.com/kellnr/kellnr/pull/649))

* feat: user groups management

* feat: ui improvement

* remove anyhow

* fix broken landing page layout

* icon color

add back the color for icons of the statistics-card to allow gold,
silver and bronce medals.

* remove unused component

* improve css for safari

* remove armv7 support

* build(deps): bump flate2 from 1.1.0 to 1.1.1 ([#668](https://github.com/kellnr/kellnr/pull/668))

Bumps [flate2](https://github.com/rust-lang/flate2-rs) from 1.1.0 to 1.1.1.
- [Release notes](https://github.com/rust-lang/flate2-rs/releases)
- [Commits](https://github.com/rust-lang/flate2-rs/compare/1.1.0...1.1.1)

---
updated-dependencies:
- dependency-name: flate2
  dependency-version: 1.1.1
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump tokio from 1.44.1 to 1.44.2 ([#667](https://github.com/kellnr/kellnr/pull/667))

Bumps [tokio](https://github.com/tokio-rs/tokio) from 1.44.1 to 1.44.2.
- [Release notes](https://github.com/tokio-rs/tokio/releases)
- [Commits](https://github.com/tokio-rs/tokio/compare/tokio-1.44.1...tokio-1.44.2)

---
updated-dependencies:
- dependency-name: tokio
  dependency-version: 1.44.2
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump openssl from 0.10.71 to 0.10.72 ([#665](https://github.com/kellnr/kellnr/pull/665))

Bumps [openssl](https://github.com/sfackler/rust-openssl) from 0.10.71 to 0.10.72.
- [Release notes](https://github.com/sfackler/rust-openssl/releases)
- [Commits](https://github.com/sfackler/rust-openssl/compare/openssl-v0.10.71...openssl-v0.10.72)

---
updated-dependencies:
- dependency-name: openssl
  dependency-version: 0.10.72
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump zip from 2.5.0 to 2.6.1 ([#666](https://github.com/kellnr/kellnr/pull/666))

Bumps [zip](https://github.com/zip-rs/zip2) from 2.5.0 to 2.6.1.
- [Release notes](https://github.com/zip-rs/zip2/releases)
- [Changelog](https://github.com/zip-rs/zip2/blob/master/CHANGELOG.md)
- [Commits](https://github.com/zip-rs/zip2/compare/v2.5.0...v2.6.1)

---
updated-dependencies:
- dependency-name: zip
  dependency-version: 2.6.1
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* fix #670

rewrite filesystem storage

fix

* remove debug output

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>
Co-authored-by: badsmoke <github@badcloud.eu>
Co-authored-by: Carl Scherer <carl.scherer@kenbun.de>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Loïs Postula <lois@postu.la>
- *(deps)* bump crossbeam-channel from 0.5.14 to 0.5.15 ([#672](https://github.com/kellnr/kellnr/pull/672))
- Syncing with v5.4.0
- *(deps)* bump tokio from 1.44.1 to 1.44.2 ([#669](https://github.com/kellnr/kellnr/pull/669))
- *(deps)* bump openssl from 0.10.71 to 0.10.72 ([#664](https://github.com/kellnr/kellnr/pull/664))
- Devel ([#663](https://github.com/kellnr/kellnr/pull/663))

* Main ([#660](https://github.com/kellnr/kellnr/pull/660))

* Devel ([#553](https://github.com/kellnr/kellnr/pull/553))

* Feature #209: initial implementation of download authorization

* update npm packages

* fix missing crate description

* remove debug prints

* fix padding in readme rendering

---------

Co-authored-by: Jaŭhien Piatlicki <jauhien.piatlicki@asynchronics.com>

* check emty username and password ([#573](https://github.com/kellnr/kellnr/pull/573))

* add enpoint to get all crate versions ([#576](https://github.com/kellnr/kellnr/pull/576))

* Devel ([#585](https://github.com/kellnr/kellnr/pull/585))

* Feature #209: initial implementation of download authorization

* update npm packages

* fix missing crate description

* remove debug prints

* fix padding in readme rendering

* build(deps-dev): bump vite from 6.0.5 to 6.0.6 in /ui ([#560](https://github.com/kellnr/kellnr/pull/560))

* build(deps): bump reqwest from 0.12.9 to 0.12.11 ([#559](https://github.com/kellnr/kellnr/pull/559))

* build(deps): bump quote from 1.0.37 to 1.0.38 ([#558](https://github.com/kellnr/kellnr/pull/558))

* build(deps): bump anyhow from 1.0.94 to 1.0.95 ([#557](https://github.com/kellnr/kellnr/pull/557))

* build(deps): bump serde_json from 1.0.133 to 1.0.134 ([#555](https://github.com/kellnr/kellnr/pull/555))

* build(deps): bump serde from 1.0.216 to 1.0.217 ([#556](https://github.com/kellnr/kellnr/pull/556))

Bumps [serde](https://github.com/serde-rs/serde) from 1.0.216 to 1.0.217.
- [Release notes](https://github.com/serde-rs/serde/releases)
- [Commits](https://github.com/serde-rs/serde/compare/v1.0.216...v1.0.217)

---
updated-dependencies:
- dependency-name: serde
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps-dev): bump vite from 6.0.6 to 6.0.7 in /ui ([#566](https://github.com/kellnr/kellnr/pull/566))

* build(deps): bump hyper from 1.5.1 to 1.5.2 ([#565](https://github.com/kellnr/kellnr/pull/565))

* build(deps): bump sea-orm from 1.1.1 to 1.1.3 ([#564](https://github.com/kellnr/kellnr/pull/564))

* build(deps): bump syn from 2.0.93 to 2.0.95 ([#563](https://github.com/kellnr/kellnr/pull/563))

* build(deps): bump reqwest from 0.12.11 to 0.12.12 ([#562](https://github.com/kellnr/kellnr/pull/562))

* build(deps): bump moka from 0.12.8 to 0.12.10 ([#561](https://github.com/kellnr/kellnr/pull/561))

* build(deps): bump sea-orm from 1.1.3 to 1.1.4 ([#571](https://github.com/kellnr/kellnr/pull/571))

Bumps [sea-orm](https://github.com/SeaQL/sea-orm) from 1.1.3 to 1.1.4.
- [Release notes](https://github.com/SeaQL/sea-orm/releases)
- [Changelog](https://github.com/SeaQL/sea-orm/blob/master/CHANGELOG.md)
- [Commits](https://github.com/SeaQL/sea-orm/compare/1.1.3...1.1.4)

---
updated-dependencies:
- dependency-name: sea-orm
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump proc-macro2 from 1.0.92 to 1.0.93 ([#570](https://github.com/kellnr/kellnr/pull/570))

Bumps [proc-macro2](https://github.com/dtolnay/proc-macro2) from 1.0.92 to 1.0.93.
- [Release notes](https://github.com/dtolnay/proc-macro2/releases)
- [Commits](https://github.com/dtolnay/proc-macro2/compare/1.0.92...1.0.93)

---
updated-dependencies:
- dependency-name: proc-macro2
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump serde_json from 1.0.134 to 1.0.135 ([#569](https://github.com/kellnr/kellnr/pull/569))

Bumps [serde_json](https://github.com/serde-rs/json) from 1.0.134 to 1.0.135.
- [Release notes](https://github.com/serde-rs/json/releases)
- [Commits](https://github.com/serde-rs/json/compare/v1.0.134...v1.0.135)

---
updated-dependencies:
- dependency-name: serde_json
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* build(deps): bump sea-orm-migration from 1.1.1 to 1.1.3 ([#568](https://github.com/kellnr/kellnr/pull/568))

Bumps [sea-orm-migration](https://github.com/SeaQL/sea-o