### PR TITLE
chore: release v5.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "cargo",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "bytes",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "async-std",
  "chrono",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-minio-testcontainer"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "config",
  "serde",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "5.14.0"
+version = "5.14.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "5.14.0"
+version = "5.14.1"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -18,23 +18,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "5.14.0", path = "./crates/appstate" }
-kellnr-auth = { version = "5.14.0", path = "./crates/auth" }
-kellnr-common = { version = "5.14.0", path = "./crates/common" }
-kellnr-db = { version = "5.14.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "5.14.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "5.14.0", path = "./crates/docs" }
-kellnr-entity = { version = "5.14.0", path = "./crates/db/entity" }
-kellnr-error = { version = "5.14.0", path = "./crates/error" }
-kellnr-index = { version = "5.14.0", path = "./crates/index" }
-kellnr-migration = { version = "5.14.0", path = "./crates/db/migration" }
-kellnr-minio-testcontainer = { version = "5.14.0", path = "./crates/storage/minio-testcontainer" }
-kellnr-registry = { version = "5.14.0", path = "./crates/registry" }
-kellnr-settings = { version = "5.14.0", path = "./crates/settings" }
-kellnr-storage = { version = "5.14.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "5.14.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "5.14.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "5.14.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "5.14.1", path = "./crates/appstate" }
+kellnr-auth = { version = "5.14.1", path = "./crates/auth" }
+kellnr-common = { version = "5.14.1", path = "./crates/common" }
+kellnr-db = { version = "5.14.1", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "5.14.1", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "5.14.1", path = "./crates/docs" }
+kellnr-entity = { version = "5.14.1", path = "./crates/db/entity" }
+kellnr-error = { version = "5.14.1", path = "./crates/error" }
+kellnr-index = { version = "5.14.1", path = "./crates/index" }
+kellnr-migration = { version = "5.14.1", path = "./crates/db/migration" }
+kellnr-minio-testcontainer = { version = "5.14.1", path = "./crates/storage/minio-testcontainer" }
+kellnr-registry = { version = "5.14.1", path = "./crates/registry" }
+kellnr-settings = { version = "5.14.1", path = "./crates/settings" }
+kellnr-storage = { version = "5.14.1", path = "./crates/storage" }
+kellnr-web-ui = { version = "5.14.1", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "5.14.1", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "5.14.1", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v5.14.1

This release updates all workspace packages to version **5.14.1**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-minio-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [5.14.1](https://github.com/kellnr/kellnr/compare/v5.14.0...v5.14.1) - 2026-01-26

### Fixed

- web UI open documentation link ignores kellnr origin  path ([#985](https://github.com/kellnr/kellnr/pull/985))

### Other

- reuse reqwest client ([#984](https://github.com/kellnr/kellnr/pull/984))

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
