### PR TITLE
docs: improve contribution experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,14 +45,14 @@ The following tools are needed to build Kellnr:
 
 ### Using Nix
 
-For an easy development environment, you can use the provided `flake.nix`:
+For an easy development environment, you can use the provided `flake.nix`. Install nix from (download page)[https://nixos.org/download/].
 
 ```bash
 # Start a development shell
-nix develop
+nix develop --extra-experimental-features nix-command --extra-experimental-features flakes
 
 # Build the project
-nix build
+nix build --extra-experimental-features nix-command --extra-experimental-features flakes
 ```
 
 ### Build and Test


### PR DESCRIPTION
I tried to do the proper "nix" route, and ran into multiple issues. I suspect others may too, so this is more of a WIP PR to optimize contribution experience.

* [x] added link to install nix
* [x] `nix develop` command wouldn't work without extra params. Fixed in docs.
* [x] `nix build` command wouldn't work without extra params. Fixed in docs.
* [ ] `nix build` would only use about 2 cores, making the build extremely slow. Not sure what needs changing.
* [ ] Does nix use regular `cargo build`, or does it try to take over some of that process (similar to Bazel), and possibly result in different behavior?