### PR TITLE
chore: release v6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "cargo",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "bytes",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "5.14.1"
+version = "6.0.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "5.14.1"
+version = "6.0.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "5.14.1", path = "./crates/appstate" }
-kellnr-auth = { version = "5.14.1", path = "./crates/auth" }
-kellnr-common = { version = "5.14.1", path = "./crates/common" }
-kellnr-db = { version = "5.14.1", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "5.14.1", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "5.14.1", path = "./crates/docs" }
-kellnr-entity = { version = "5.14.1", path = "./crates/db/entity" }
-kellnr-error = { version = "5.14.1", path = "./crates/error" }
-kellnr-index = { version = "5.14.1", path = "./crates/index" }
-kellnr-migration = { version = "5.14.1", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "5.14.1", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "5.14.1", path = "./crates/registry" }
-kellnr-settings = { version = "5.14.1", path = "./crates/settings" }
-kellnr-storage = { version = "5.14.1", path = "./crates/storage" }
-kellnr-web-ui = { version = "5.14.1", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "5.14.1", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "5.14.1", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.0.0", path = "./crates/appstate" }
+kellnr-auth = { version = "6.0.0", path = "./crates/auth" }
+kellnr-common = { version = "6.0.0", path = "./crates/common" }
+kellnr-db = { version = "6.0.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.0.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.0.0", path = "./crates/docs" }
+kellnr-entity = { version = "6.0.0", path = "./crates/db/entity" }
+kellnr-error = { version = "6.0.0", path = "./crates/error" }
+kellnr-index = { version = "6.0.0", path = "./crates/index" }
+kellnr-migration = { version = "6.0.0", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.0.0", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.0.0", path = "./crates/registry" }
+kellnr-settings = { version = "6.0.0", path = "./crates/settings" }
+kellnr-storage = { version = "6.0.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.0.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.0.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.0.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION
## New release v6.0.0

This release updates all workspace packages to version **6.0.0**.

<details><summary><i><b>Changelog</b></i></summary>

## [6.0.0](https://github.com/kellnr/kellnr/compare/v5.14.1...v6.0.0) - 2026-02-12

### Added

- add update-npm-hash command
- add CLI for kellnr
- add oauth2/openidconnect
- don't show doc generation button in crate view if doc generation is disabled
- add expand/collapse functionality in Startup Configuration ([#1019](https://github.com/kellnr/kellnr/pull/1019))
- improve display of config values in UI #1014
- add test coverage
- print Kellnr URL on startup ([#1011](https://github.com/kellnr/kellnr/pull/1011))
- add OpenAPI docs
- add toolchain server ([#1009](https://github.com/kellnr/kellnr/pull/1009))
- add Windows builds

### Fixed

- docs build endpoint not available for non-admin users
- web-ui routing paths when origin.path is used ([#1023](https://github.com/kellnr/kellnr/pull/1023))
- make "nix build" more stable to package-lock.json changes
- minor clippy issues ([#1027](https://github.com/kellnr/kellnr/pull/1027))
- oauth2 implementation ([#1022](https://github.com/kellnr/kellnr/pull/1022))
- remove default admin token #1012
- admin user allowed to delete/lock himself #1015 
- don't show doc generation button in crate view if doc generation is disabled ([#1042](https://github.com/kellnr/kellnr/pull/1042))

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
