### PR TITLE
chore: switch npm install to npm ci for cleaner dependency installation

### DIFF
--- a/justfile
+++ b/justfile
@@ -73,12 +73,12 @@ fmt-check:
     cargo fmt --all -- --check
 
 [unix]
-run: npm-build build
-    cargo run -- start
+run *ARGS='start': npm-build build
+    cargo run -- {{ARGS}}
 
 [windows]
-run: npm-build build
-    {{ setup-msvc }} cargo run --no-default-features -- start
+run *ARGS='start': npm-build build
+    {{ setup-msvc }} cargo run --no-default-features -- {{ARGS}}
 
 [unix]
 test: npm-build


### PR DESCRIPTION
`npm ci` apparently prevents any lock file modification, keeping things cleaner