### PR TITLE
refactor(db): simplify/dedup a few more db functions

### DIFF
--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -159,7 +159,7 @@ impl Database {
     /// Looks up a `crate_user` by crate name and user name; returns `None` if not found.
     async fn get_crate_user_by_crate_and_user(
         &self,
-        crate_name: &str,
+        crate_name: &NormalizedName,
         user: &str,
     ) -> DbResult<Option<crate_user::Model>> {
         crate_user::Entity::find()
@@ -167,7 +167,7 @@ impl Database {
             .join(JoinType::InnerJoin, crate_user::Relation::User.def())
             .filter(
                 Cond::all()
-                    .add(krate::Column::Name.eq(crate_name))
+                    .add(krate::Column::Name.eq(&**crate_name))
                     .add(user::Column::Name.eq(user)),
             )
             .one(&self.db_con)
@@ -719,7 +719,7 @@ impl DbProvider for Database {
         Ok(())
     }
 
-    async fn delete_crate_user(&self, crate_name: &str, user: &str) -> DbResult<()> {
+    async fn delete_crate_user(&self, crate_name: &NormalizedName, user: &str) -> DbResult<()> {
         self.get_crate_user_by_crate_and_user(crate_name, user)
             .await?
             .ok_or_else(|| DbError::UserNotFound(user.to_string()))?

--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -155,7 +155,7 @@ pub trait DbProvider: Send + Sync {
     async fn get_auth_tokens(&self, user_name: &str) -> DbResult<Vec<AuthToken>>;
     async fn delete_auth_token(&self, id: i32) -> DbResult<()>;
     async fn delete_owner(&self, crate_name: &str, owner: &str) -> DbResult<()>;
-    async fn delete_crate_user(&self, crate_name: &str, user: &str) -> DbResult<()>;
+    async fn delete_crate_user(&self, crate_name: &NormalizedName, user: &str) -> DbResult<()>;
     async fn add_user(
         &self,
         name: &str,
@@ -521,7 +521,7 @@ pub mod mock {
                 unimplemented!()
             }
 
-            async fn delete_crate_user(&self, crate_name: &str, user: &str) -> DbResult<()>{
+            async fn delete_crate_user(&self, crate_name: &NormalizedName, user: &str) -> DbResult<()>{
                 unimplemented!()
             }
 


### PR DESCRIPTION
This pull request refactors the database access logic in `crates/db/src/database/mod.rs` to reduce code duplication and improve maintainability. It introduces new helper methods for common lookup patterns and updates several methods to use these helpers, resulting in cleaner and more concise code.

Refactoring and code deduplication:

* Added three new helper methods to the `Database` implementation: `get_crate_group_by_name_and_group`, `get_group_user_by_group_and_user`, and `get_crate_user_by_crate_and_user`. These methods encapsulate common database lookup patterns for crate groups, group users, and crate users.

* Updated the `is_crate_user`, `is_crate_group`, and `is_group_user` methods in the `DbProvider` implementation to use the new helper methods, replacing the repeated query logic with calls to the helpers. [[1]](diffhunk://#diff-5a1c2a6037d8057978b7d79419ef1fb44486ce70db957bdf9e726701e9cf1df4L383-R450) [[2]](diffhunk://#diff-5a1c2a6037d8057978b7d79419ef1fb44486ce70db957bdf9e726701e9cf1df4L429-R473)

* Refactored the `delete_crate_user`, `delete_crate_group`, and `delete_group_user` methods to use the new helper methods for lookups before deletion, further reducing code repetition and improving error handling consistency.