### PR TITLE
feat: add `into_inner` method to `NormalizedName`, `OriginalName`, an…

### DIFF
--- a/crates/common/src/normalized_name.rs
+++ b/crates/common/src/normalized_name.rs
@@ -15,6 +15,10 @@ impl NormalizedName {
     pub fn from_unchecked_str(name: &str) -> Self {
         NormalizedName(name.to_owned())
     }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 impl From<OriginalName> for NormalizedName {

--- a/crates/common/src/original_name.rs
+++ b/crates/common/src/original_name.rs
@@ -27,6 +27,9 @@ impl OriginalName {
     pub fn from_unchecked(name: String) -> Self {
         Self(name)
     }
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 impl TryFrom<String> for OriginalName {

--- a/crates/common/src/version.rs
+++ b/crates/common/src/version.rs
@@ -20,6 +20,9 @@ impl Version {
     pub fn from_unchecked_str(version: &str) -> Self {
         Self(version.to_string())
     }
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 impl TryFrom<&str> for Version {


### PR DESCRIPTION
…d `Version`

a common pattern to get inner value while dropping the wrapper, without re-allocation