### PR TITLE
refactor: simplify DB value usage

### DIFF
--- a/crates/common/src/normalized_name.rs
+++ b/crates/common/src/normalized_name.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use sea_orm::Value;
+
 use crate::original_name::OriginalName;
 
 /// Index name is a lowercase version of the crate name
@@ -30,6 +32,18 @@ impl From<OriginalName> for NormalizedName {
 impl From<&OriginalName> for NormalizedName {
     fn from(name: &OriginalName) -> Self {
         NormalizedName(name.to_lowercase())
+    }
+}
+
+impl From<NormalizedName> for Value {
+    fn from(value: NormalizedName) -> Self {
+        Value::String(Some(value.0))
+    }
+}
+
+impl From<&NormalizedName> for Value {
+    fn from(value: &NormalizedName) -> Self {
+        Value::String(Some(value.0.clone()))
     }
 }
 

--- a/crates/common/src/original_name.rs
+++ b/crates/common/src/original_name.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::ops::Deref;
 
 use regex::Regex;
+use sea_orm::Value;
 use thiserror::Error;
 use utoipa::ToSchema;
 
@@ -57,6 +58,18 @@ impl From<&OriginalName> for String {
 impl From<OriginalName> for String {
     fn from(name: OriginalName) -> Self {
         name.to_string()
+    }
+}
+
+impl From<OriginalName> for Value {
+    fn from(value: OriginalName) -> Self {
+        Value::String(Some(value.0))
+    }
+}
+
+impl From<&OriginalName> for Value {
+    fn from(value: &OriginalName) -> Self {
+        Value::String(Some(value.0.clone()))
     }
 }
 

--- a/crates/common/src/version.rs
+++ b/crates/common/src/version.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
 
+use sea_orm::Value;
 use thiserror::Error;
 use utoipa::ToSchema;
 
@@ -22,6 +23,18 @@ impl Version {
     }
     pub fn into_inner(self) -> String {
         self.0
+    }
+}
+
+impl From<Version> for Value {
+    fn from(value: Version) -> Self {
+        Value::String(Some(value.0))
+    }
+}
+
+impl From<&Version> for Value {
+    fn from(value: &Version) -> Self {
+        Value::String(Some(value.0.clone()))
     }
 }
 

--- a/crates/settings/src/cli.rs
+++ b/crates/settings/src/cli.rs
@@ -5,8 +5,6 @@ use clap_serde_derive::ClapSerde;
 use config::ConfigError;
 use toml::Value;
 
-use crate::SourceMap;
-use crate::compile_time_config;
 use crate::config_source::{ConfigSource, track_env_sources};
 use crate::docs::Docs;
 use crate::local::Local;
@@ -20,6 +18,7 @@ use crate::s3::S3;
 use crate::settings::Settings;
 use crate::setup::Setup;
 use crate::toolchain::Toolchain;
+use crate::{SourceMap, compile_time_config};
 
 /// Compare two Settings structs and mark all differences with the given source.
 ///


### PR DESCRIPTION
* Do not create errors unless needed (use lambdas)
* allow custom types to be used in queries as is without the deref magic
* also, for queries, do not clone if not needed
* added a version helper
* use `into_iter` where appropriate to reduce cloning too