### PR TITLE
chore: release v6.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "quote",
  "syn 2.0.115",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "cargo",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "bytes",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "async-std",
  "chrono",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "quote",
  "syn 2.0.115",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -5420,7 +5420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -8591,7 +8591,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.114",
+ "syn 2.0.115",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -8607,7 +8607,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.115",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.0.0"
+version = "6.0.1"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.0.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.0.0", path = "./crates/auth" }
-kellnr-common = { version = "6.0.0", path = "./crates/common" }
-kellnr-db = { version = "6.0.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.0.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.0.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.0.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.0.0", path = "./crates/error" }
-kellnr-index = { version = "6.0.0", path = "./crates/index" }
-kellnr-migration = { version = "6.0.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.0.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.0.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.0.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.0.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.0.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.0.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.0.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.0.1", path = "./crates/appstate" }
+kellnr-auth = { version = "6.0.1", path = "./crates/auth" }
+kellnr-common = { version = "6.0.1", path = "./crates/common" }
+kellnr-db = { version = "6.0.1", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.0.1", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.0.1", path = "./crates/docs" }
+kellnr-entity = { version = "6.0.1", path = "./crates/db/entity" }
+kellnr-error = { version = "6.0.1", path = "./crates/error" }
+kellnr-index = { version = "6.0.1", path = "./crates/index" }
+kellnr-migration = { version = "6.0.1", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.0.1", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.0.1", path = "./crates/registry" }
+kellnr-settings = { version = "6.0.1", path = "./crates/settings" }
+kellnr-storage = { version = "6.0.1", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.0.1", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.0.1", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.0.1", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION
## New release v6.0.1

This release updates all workspace packages to version **6.0.1**.

<details><summary><i><b>Changelog</b></i></summary>

## [6.0.1](https://github.com/kellnr/kellnr/compare/v6.0.0...v6.0.1) - 2026-02-16

### Fixed

- non-admin user not able to open settings when auth_required = true ([#1071](https://github.com/kellnr/kellnr/pull/1071))
- non-admin user not able to open settings when auth_required = true #1070

### Other

- fix playwright version mismatch
- update NPM packages
- *(deps-dev)* bump eslint from 9.39.2 to 10.0.0 in /ui ([#1058](https://github.com/kellnr/kellnr/pull/1058))
- *(deps-dev)* bump eslint-plugin-vue from 10.7.0 to 10.8.0 in /ui ([#1056](https://github.com/kellnr/kellnr/pull/1056))
- *(deps-dev)* bump @eslint/js from 9.39.2 to 10.0.1 in /ui ([#1059](https://github.com/kellnr/kellnr/pull/1059))
- *(deps)* bump marked from 17.0.1 to 17.0.2 in /ui ([#1061](https://github.com/kellnr/kellnr/pull/1061))
- *(deps)* bump actions/checkout from 4 to 6 ([#1057](https://github.com/kellnr/kellnr/pull/1057))
- *(deps)* bump actions/setup-node from 4 to 6 ([#1055](https://github.com/kellnr/kellnr/pull/1055))
- *(deps)* bump vue from 3.5.27 to 3.5.28 in /ui ([#1060](https://github.com/kellnr/kellnr/pull/1060))
- *(deps)* bump clap from 4.5.54 to 4.5.58 ([#1062](https://github.com/kellnr/kellnr/pull/1062))
- *(deps)* bump syn from 2.0.114 to 2.0.115 ([#1063](https://github.com/kellnr/kellnr/pull/1063))
- *(deps)* bump testcontainers from 0.26.3 to 0.27.0 ([#1065](https://github.com/kellnr/kellnr/pull/1065))
- *(deps)* bump uuid from 1.19.0 to 1.21.0 ([#1066](https://github.com/kellnr/kellnr/pull/1066))
- *(config)* dedup config management and envvar mapping ([#1067](https://github.com/kellnr/kellnr/pull/1067))
- fix broken migration test
- *(config)* dedup config management and envvar mapping
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump uuid from 1.19.0 to 1.21.0
- *(deps)* bump testcontainers from 0.26.3 to 0.27.0
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump syn from 2.0.114 to 2.0.115
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump clap from 4.5.54 to 4.5.58
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump marked from 17.0.1 to 17.0.2 in /ui
- *(deps)* bump vue from 3.5.27 to 3.5.28 in /ui
- *(deps-dev)* bump @eslint/js from 9.39.2 to 10.0.1 in /ui
- *(deps)* bump actions/checkout from 4 to 6
- *(deps-dev)* bump eslint from 9.39.2 to 10.0.0 in /ui
- *(deps-dev)* bump eslint-plugin-vue from 10.7.0 to 10.8.0 in /ui
- *(deps)* bump actions/setup-node from 4 to 6
- Fix broken Windows build

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
