### PR TITLE
chore: release v6.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "chrono",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "quote",
  "syn 2.0.115",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "cargo",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "bytes",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "chrono",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "async-std",
  "chrono",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "chrono",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "quote",
  "syn 2.0.115",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.0.1"
+version = "6.0.2"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.0.1", path = "./crates/appstate" }
-kellnr-auth = { version = "6.0.1", path = "./crates/auth" }
-kellnr-common = { version = "6.0.1", path = "./crates/common" }
-kellnr-db = { version = "6.0.1", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.0.1", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.0.1", path = "./crates/docs" }
-kellnr-entity = { version = "6.0.1", path = "./crates/db/entity" }
-kellnr-error = { version = "6.0.1", path = "./crates/error" }
-kellnr-index = { version = "6.0.1", path = "./crates/index" }
-kellnr-migration = { version = "6.0.1", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.0.1", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.0.1", path = "./crates/registry" }
-kellnr-settings = { version = "6.0.1", path = "./crates/settings" }
-kellnr-storage = { version = "6.0.1", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.0.1", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.0.1", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.0.1", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.0.2", path = "./crates/appstate" }
+kellnr-auth = { version = "6.0.2", path = "./crates/auth" }
+kellnr-common = { version = "6.0.2", path = "./crates/common" }
+kellnr-db = { version = "6.0.2", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.0.2", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.0.2", path = "./crates/docs" }
+kellnr-entity = { version = "6.0.2", path = "./crates/db/entity" }
+kellnr-error = { version = "6.0.2", path = "./crates/error" }
+kellnr-index = { version = "6.0.2", path = "./crates/index" }
+kellnr-migration = { version = "6.0.2", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.0.2", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.0.2", path = "./crates/registry" }
+kellnr-settings = { version = "6.0.2", path = "./crates/settings" }
+kellnr-storage = { version = "6.0.2", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.0.2", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.0.2", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.0.2", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION
## New release v6.0.2

This release updates all workspace packages to version **6.0.2**.


<details><summary><i><b>Changelog</b></i></summary>

## [6.0.2](https://github.com/kellnr/kellnr/compare/v6.0.1...v6.0.2) - 2026-02-19

### Fixed

- broken S3 credential handling ([#1076](https://github.com/kellnr/kellnr/pull/1076))
- cratesio cache not all versions available ([#1077](https://github.com/kellnr/kellnr/pull/1077))

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
