### PR TITLE
chore: release v6.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "cargo",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "bytes",
@@ -3950,7 +3950,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "async-std",
  "chrono",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "chrono",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.0.2"
+version = "6.0.3"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.0.2", path = "./crates/appstate" }
-kellnr-auth = { version = "6.0.2", path = "./crates/auth" }
-kellnr-common = { version = "6.0.2", path = "./crates/common" }
-kellnr-db = { version = "6.0.2", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.0.2", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.0.2", path = "./crates/docs" }
-kellnr-entity = { version = "6.0.2", path = "./crates/db/entity" }
-kellnr-error = { version = "6.0.2", path = "./crates/error" }
-kellnr-index = { version = "6.0.2", path = "./crates/index" }
-kellnr-migration = { version = "6.0.2", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.0.2", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.0.2", path = "./crates/registry" }
-kellnr-settings = { version = "6.0.2", path = "./crates/settings" }
-kellnr-storage = { version = "6.0.2", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.0.2", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.0.2", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.0.2", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.0.3", path = "./crates/appstate" }
+kellnr-auth = { version = "6.0.3", path = "./crates/auth" }
+kellnr-common = { version = "6.0.3", path = "./crates/common" }
+kellnr-db = { version = "6.0.3", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.0.3", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.0.3", path = "./crates/docs" }
+kellnr-entity = { version = "6.0.3", path = "./crates/db/entity" }
+kellnr-error = { version = "6.0.3", path = "./crates/error" }
+kellnr-index = { version = "6.0.3", path = "./crates/index" }
+kellnr-migration = { version = "6.0.3", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.0.3", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.0.3", path = "./crates/registry" }
+kellnr-settings = { version = "6.0.3", path = "./crates/settings" }
+kellnr-storage = { version = "6.0.3", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.0.3", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.0.3", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.0.3", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION
## New release v6.0.3

This release updates all workspace packages to version **6.0.3**.

<details><summary><i><b>Changelog</b></i></summary>

## [6.0.3](https://github.com/kellnr/kellnr/compare/v6.0.2...v6.0.3) - 2026-02-21

### Fixed

- *(oauth2)* normalize origin.path to prevent double slash in callback URL [#1080](https://github.com/kellnr/kellnr/pull/1080)

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
