### PR TITLE
fix(oauth2): normalize origin.path to prevent double slash in callbac…

### DIFF
--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -316,7 +316,14 @@ async fn init_oauth2_handler(settings: &Settings) -> Option<Arc<OAuth2Handler>> 
     let protocol = &settings.origin.protocol; // Protocol enum implements Display
     let host = &settings.origin.hostname;
     let port = settings.origin.port;
-    let path_prefix = settings.origin.path.trim();
+
+    // FIX: Normalize path prefix to avoid double slashes
+    let raw_path = settings.origin.path.trim();
+    let path_prefix = if raw_path.is_empty() || raw_path == "/" {
+        String::new()
+    } else {
+        raw_path.trim_end_matches('/').to_string()
+    };
 
     let callback_url = if port == 443 || port == 80 {
         format!("{protocol}://{host}{path_prefix}/api/v1/oauth2/callback")


### PR DESCRIPTION
### Problem
When `origin.path` is set to `/`, the OAuth2 callback URL is built as `//api/v1/oauth2/callback`, producing an invalid redirect URI. This breaks the authorization-code exchange / redirect flow when deploying behind an ingress.

### Change
Normalize `origin.path` when building the OAuth2 callback URL:
- `""` or `/` → empty prefix
- `/foo/` → `/foo`

### Result
Prevents `//api/v1/oauth2/callback` and avoids invalid `redirect_uri` values during OIDC login.

### Notes
No behavior change for non-root subpaths; only normalizes trailing slashes / root path.