### PR TITLE
Fix `max_crate_size` default value

### DIFF
--- a/crates/settings/src/registry.rs
+++ b/crates/settings/src/registry.rs
@@ -30,8 +30,8 @@ pub struct Registry {
     #[arg(id = "registry-cache-size", long = "registry-cache-size")]
     pub cache_size: u64,
 
-    /// Max crate size in KB
-    #[default(10 * 1000)]
+    /// Max crate size in MB
+    #[default(10)]
     #[arg(id = "registry-max-crate-size", long = "registry-max-crate-size")]
     pub max_crate_size: u64,
 


### PR DESCRIPTION
max_crate_size is in units of MB, but the comment and default value incorrectly assumed KB.

Usage: https://github.com/kellnr/kellnr/blob/dd24826e91ab09bcac578f0f00946ab819e22a13/crates/kellnr/src/routes/kellnr_api_routes.rs#L17
The docs (https://kellnr.io/documentation) also state that it is in MB.