### PR TITLE
Enable support for splitting storage backends over registry-owned crates, proxied crates, and toolchain data.

### DIFF
--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -14,7 +14,7 @@ use kellnr_db::{ConString, Database, DbProvider, PgConString, SqliteConString};
 use kellnr_index::cratesio_prefetch_api::{
     CratesIoPrefetchArgs, UPDATE_CACHE_TIMEOUT_SECS, init_cratesio_prefetch_thread,
 };
-use kellnr_settings::{CliResult, LogFormat, Settings, ShowConfigOptions, parse_cli};
+use kellnr_settings::{CliResult, LogFormat, Settings, ShowConfigOptions, parse_cli, storage::StorageBackend};
 use kellnr_storage::cached_crate_storage::DynStorage;
 use kellnr_storage::cratesio_crate_storage::CratesIoCrateStorage;
 use kellnr_storage::fs_storage::FSStorage;
@@ -119,8 +119,15 @@ async fn run_server(settings: Settings) {
         .await
         .expect("Failed to create data directory.");
 
-    // Initialize kellnr crate storage
-    let crate_storage: Arc<KellnrCrateStorage> = init_kellnr_crate_storage(&settings).into();
+    // Initialize kellnr crate storage backend, Crates.io Proxy storage backend, 
+    // and toolchain storage backends.
+    let (
+        crate_storage,
+        cratesio_storage,
+        toolchain_storage
+    ) = init_storages(&settings);
+
+    // // Initialize kellnr crate storage
 
     // Create the database connection. Has to be done after the index and storage
     // as the needed folders for the sqlite database may not have been created before that.
@@ -130,8 +137,7 @@ async fn run_server(settings: Settings) {
         .expect("Failed to create database");
     let db = Arc::new(db) as Arc<dyn DbProvider>;
 
-    // Crates.io Proxy
-    let cratesio_storage: Arc<CratesIoCrateStorage> = init_cratesio_storage(&settings).into();
+    // // Crates.io Proxy
     let (cratesio_prefetch_sender, cratesio_prefetch_receiver) =
         flume::unbounded::<CratesioPrefetchMsg>();
 
@@ -170,9 +176,6 @@ async fn run_server(settings: Settings) {
         settings.registry.token_cache_ttl_seconds,
         settings.registry.token_cache_max_capacity,
     ));
-
-    // Initialize toolchain storage if enabled
-    let toolchain_storage = init_toolchain_storage(&settings);
 
     // Initialize OAuth2/OIDC handler if enabled
     let oauth2_handler = init_oauth2_handler(&settings).await;
@@ -272,39 +275,51 @@ async fn init_docs_hosting(
     }
 }
 
-fn init_cratesio_storage(settings: &Settings) -> CratesIoCrateStorage {
-    let storage = init_storage(&settings.crates_io_path_or_bucket(), settings);
-    CratesIoCrateStorage::new(settings, storage)
-}
+fn init_storages(settings: &Settings) -> (Arc<KellnrCrateStorage>, Arc<CratesIoCrateStorage>, Option<Arc<ToolchainStorage>>) {
 
-fn init_kellnr_crate_storage(settings: &Settings) -> KellnrCrateStorage {
-    let storage = init_storage(&settings.crates_path_or_bucket(), settings);
-    KellnrCrateStorage::new(settings, storage)
-}
+    let kellnr_storage: Arc<KellnrCrateStorage> = {
+        match &settings.storage.kellnr_crates {
+            StorageBackend::File(config) => {
+                let storage = FSStorage::try_from(config).expect("Failed to create FS storage for 'kellnr_crates'");
+                KellnrCrateStorage::new(settings, Box::new(storage) as DynStorage).into()
+            },
+            StorageBackend::S3(config) => {
+                let storage = S3Storage::try_from(config).expect("Failed to create S3 storage for 'kellnr_crates'");
+                KellnrCrateStorage::new(settings, Box::new(storage) as DynStorage).into()
+            },
+        }
+    };
 
-fn init_storage(folder: &str, settings: &Settings) -> DynStorage {
-    if settings.s3.enabled {
-        let s = S3Storage::try_from((folder, settings)).expect("Failed to create S3 storage.");
-        Box::new(s) as DynStorage
-    } else {
-        let s = FSStorage::new(folder).expect("Failed to create FS storage.");
-        Box::new(s) as DynStorage
+    let crates_io_storage: Arc<CratesIoCrateStorage> = {
+        match &settings.storage.crates_io {
+            StorageBackend::File(config) => {
+                let storage = FSStorage::try_from(config).expect("Failed to create FS storage for 'crates_io'");
+                CratesIoCrateStorage::new(settings, Box::new(storage) as DynStorage).into()
+            },
+            StorageBackend::S3(config) => {
+                let storage = S3Storage::try_from(config).expect("Failed to create S3 storage for 'crates_io'");
+                CratesIoCrateStorage::new(settings, Box::new(storage) as DynStorage).into()
+            }
+        }
+    };
+    let mut toolchain_storage = None;
+    if settings.toolchain.enabled {
+        match &settings.storage.toolchain {
+            StorageBackend::File(config) => {
+                let storage = FSStorage::try_from(config).expect("Failed to create FS storage for 'toolchain'");
+                toolchain_storage = Some(ToolchainStorage::new(Box::new(storage) as DynStorage).into());
+            },
+            StorageBackend::S3(config) => {
+                let storage = S3Storage::try_from(config).expect("Failed to create S3 storage for 'toolchain'");
+                toolchain_storage = Some(ToolchainStorage::new(Box::new(storage) as DynStorage).into());
+            }
+        }
     }
+    (kellnr_storage, crates_io_storage, toolchain_storage)
 }
 
 fn init_webhook_service(db: Arc<dyn DbProvider + 'static>) {
     kellnr_webhooks::run_webhook_service(db);
-}
-
-fn init_toolchain_storage(settings: &Arc<Settings>) -> Option<Arc<ToolchainStorage>> {
-    if !settings.toolchain.enabled {
-        return None;
-    }
-
-    let storage = init_storage(&settings.toolchain_path_or_bucket(), settings);
-    let toolchain_storage = ToolchainStorage::new(storage);
-
-    Some(Arc::new(toolchain_storage))
 }
 
 async fn init_oauth2_handler(settings: &Settings) -> Option<Arc<OAuth2Handler>> {

--- a/crates/settings/src/cli.rs
+++ b/crates/settings/src/cli.rs
@@ -14,7 +14,7 @@ use crate::origin::Origin;
 use crate::postgresql::Postgresql;
 use crate::proxy::Proxy;
 use crate::registry::Registry;
-use crate::s3::S3;
+use crate::storage::Storage;
 use crate::settings::Settings;
 use crate::setup::Setup;
 use crate::toolchain::Toolchain;
@@ -101,7 +101,7 @@ pub struct ServerArgs {
     pub postgresql: <Postgresql as ClapSerde>::Opt,
 
     #[command(flatten)]
-    pub s3: <S3 as ClapSerde>::Opt,
+    pub storage: <Storage as ClapSerde>::Opt,
 
     #[command(flatten)]
     pub setup: <Setup as ClapSerde>::Opt,
@@ -295,7 +295,7 @@ fn track_and_merge_cli(settings: &mut Settings, server: ServerArgs) {
     settings.docs = settings.docs.clone().merge(server.docs);
     settings.proxy = settings.proxy.clone().merge(server.proxy);
     settings.postgresql = settings.postgresql.clone().merge(server.postgresql);
-    settings.s3 = settings.s3.clone().merge(server.s3);
+    settings.storage = settings.storage.clone().merge(server.storage);
     settings.setup = settings.setup.clone().merge(server.setup);
     settings.oauth2 = settings.oauth2.clone().merge(server.oauth2);
     settings.toolchain = settings.toolchain.clone().merge(server.toolchain);

--- a/crates/settings/src/config_source.rs
+++ b/crates/settings/src/config_source.rs
@@ -63,16 +63,10 @@ const SETTING_KEYS: &[&str] = &[
     "postgresql.db",
     "postgresql.user",
     "postgresql.pwd",
-    // S3 settings
-    "s3.enabled",
-    "s3.access_key",
-    "s3.secret_key",
-    "s3.region",
-    "s3.endpoint",
-    "s3.allow_http",
-    "s3.crates_bucket",
-    "s3.cratesio_bucket",
-    "s3.toolchain_bucket",
+    // Storage settings
+    "storage.kellnr_crates",
+    "storage.crates_io",
+    "storage.toolchain",
     // Setup settings
     "setup.admin_pwd",
     "setup.admin_token",

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -15,6 +15,7 @@ pub mod registry;
 pub mod s3;
 pub mod settings;
 pub mod setup;
+pub mod storage;
 pub mod toolchain;
 
 pub use cli::{CliResult, ShowConfigOptions, get_settings_with_cli, parse_cli};

--- a/crates/settings/src/s3.rs
+++ b/crates/settings/src/s3.rs
@@ -1,42 +1,125 @@
-use clap_serde_derive::ClapSerde;
-use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, ClapSerde)]
+use clap_serde_derive::ClapSerde;
+use serde::{Deserialize, Deserializer, Serialize, de::Error};
+
+#[derive(Debug, Eq, PartialEq, Clone, ClapSerde)]
 #[serde(default)]
-pub struct S3 {
-    #[default(false)]
-    #[arg(id = "s3-enabled", long = "s3-enabled")]
-    pub enabled: bool,
+pub struct S3Config {
 
     #[default(None)]
-    #[arg(id = "s3-access-key", long = "s3-access-key")]
+    #[arg(id = "s3-config-access-key", long = "s3-config-access-key")]
     pub access_key: Option<String>,
 
     #[default(None)]
-    #[arg(id = "s3-secret-key", long = "s3-secret-key")]
+    #[arg(id = "s3-config-secret-key", long = "s3-config-secret-key")]
     pub secret_key: Option<String>,
 
     #[default(None)]
-    #[arg(id = "s3-region", long = "s3-region")]
+    #[arg(id = "s3-config-region", long = "s3-config-region")]
     pub region: Option<String>,
 
     #[default(None)]
-    #[arg(id = "s3-endpoint", long = "s3-endpoint")]
+    #[arg(id = "s3-config-endpoint", long = "s3-config-endpoint")]
     pub endpoint: Option<String>,
 
     #[default(true)]
-    #[arg(id = "s3-allow-http", long = "s3-allow-http")]
+    #[arg(id = "s3-config-allow-http", long = "s3-config-allow-http")]
     pub allow_http: bool,
 
-    #[default("kellnr-crates".to_string())]
-    #[arg(id = "s3-crates-bucket", long = "s3-crates-bucket")]
-    pub crates_bucket: String,
+    #[default("kellnr".to_string())]
+    #[arg(id = "s3-config-bucket", long = "s3-config-bucket")]
+    pub bucket: String,
+}
 
-    #[default("kellnr-cratesio".to_string())]
-    #[arg(id = "s3-cratesio-bucket", long = "s3-cratesio-bucket")]
-    pub cratesio_bucket: String,
+impl FromStr for S3Config {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut s3_config = S3Config::default();
 
-    #[default("kellnr-toolchains".to_string())]
-    #[arg(id = "s3-toolchain-bucket", long = "s3-toolchain-bucket")]
-    pub toolchain_bucket: String,
+        for keyval in s.split(',') {
+            if let Some((key, val)) = keyval.split_once('=') {
+                match key {
+                    "access_key" => {
+                        if !val.is_empty() {
+                            s3_config.access_key = Some(val.to_string());
+                        }
+                    },
+                    "secret_key" => {
+                        if !val.is_empty() {
+                            s3_config.secret_key = Some(val.to_string());
+                        }
+                    },
+                    "region" => {
+                        if !val.is_empty() {
+                            s3_config.region = Some(val.to_string());
+                        }
+                    },
+                    "endpoint" => {
+                        if !val.is_empty() {
+                            s3_config.endpoint = Some(val.to_string());
+                        }
+                    },
+                    "allow_http" => {
+                        if !val.is_empty() {
+                            match val {
+                                "1" | "true" => {
+                                    s3_config.allow_http = true;
+                                },
+                                "0" | "false" => {
+                                    s3_config.allow_http = false;
+                                },
+                                _ => {
+                                    return Err(format!("Invalid value for 'allow_http' in S3 configuration: {val}"))
+                                }
+                            }
+                        }
+                    },
+                    "bucket" => {
+                        if !val.is_empty() {
+                            s3_config.bucket = val.to_string();
+                        }
+                    },
+                    _ => {
+                        return Err(format!("Invalid key for S3 configuration: {key}"))
+                    }
+                }
+            }
+        }
+
+        Ok(s3_config)
+    }
+}
+
+impl std::fmt::Display for S3Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "access_key={},", self.access_key.as_deref().unwrap_or_default())?;
+        write!(f, "secret_key={},", self.secret_key.as_deref().unwrap_or_default())?;
+        write!(f, "region={},", self.region.as_deref().unwrap_or_default())?;
+        write!(f, "endpoint={},", self.endpoint.as_deref().unwrap_or_default())?;
+        write!(f, "bucket={},", self.bucket.as_str())?;
+        write!(f, "allow_http={}", self.allow_http)
+    }
+}
+
+impl Serialize for S3Config {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+
+impl<'de> Deserialize<'de> for S3Config {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de> {
+        
+        let s = String::deserialize(deserializer)?;
+
+        s
+        .parse()
+        .map_err(D::Error::custom)
+    }
 }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -13,7 +13,7 @@ use crate::origin::Origin;
 use crate::postgresql::Postgresql;
 use crate::proxy::Proxy;
 use crate::registry::Registry;
-use crate::s3::S3;
+use crate::storage::Storage;
 use crate::setup::Setup;
 use crate::toolchain::Toolchain;
 
@@ -28,7 +28,7 @@ pub struct Settings {
     pub local: Local,
     pub origin: Origin,
     pub postgresql: Postgresql,
-    pub s3: S3,
+    pub storage: Storage,
     pub oauth2: OAuth2,
     pub toolchain: Toolchain,
     /// Tracks the source (default, toml, env, cli) for each setting.
@@ -48,7 +48,7 @@ impl Default for Settings {
             local: Local::default(),
             origin: Origin::default(),
             postgresql: Postgresql::default(),
-            s3: S3::default(),
+            storage: Storage::default(),
             oauth2: OAuth2::default(),
             toolchain: Toolchain::default(),
             sources: init_default_sources(),
@@ -115,32 +115,8 @@ impl Settings {
         format!("{}/crates", self.registry.data_dir)
     }
 
-    pub fn crates_path_or_bucket(&self) -> String {
-        if self.s3.enabled {
-            self.s3.crates_bucket.clone()
-        } else {
-            self.crates_path()
-        }
-    }
-
-    pub fn crates_io_path_or_bucket(&self) -> String {
-        if self.s3.enabled {
-            self.s3.cratesio_bucket.clone()
-        } else {
-            self.crates_io_path()
-        }
-    }
-
     pub fn toolchain_path(&self) -> String {
         format!("{}/toolchains", self.registry.data_dir)
-    }
-
-    pub fn toolchain_path_or_bucket(&self) -> String {
-        if self.s3.enabled {
-            self.s3.toolchain_bucket.clone()
-        } else {
-            self.toolchain_path()
-        }
     }
 }
 

--- a/crates/settings/src/storage.rs
+++ b/crates/settings/src/storage.rs
@@ -1,0 +1,205 @@
+use std::str::FromStr;
+
+use clap_serde_derive::ClapSerde;
+use clap::{Parser, ValueEnum};
+use serde::{Deserialize, Deserializer, Serialize};
+use url::Url;
+use crate::deserialize_with::DeserializeWith;
+use crate::s3::S3Config;
+use serde::de::Error;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, ClapSerde)]
+pub struct FileConfig {
+    pub folder: String
+}
+
+impl FileConfig {
+    pub fn new(s: impl AsRef<str>) -> Self {
+        Self {
+            folder: s.as_ref().to_string()
+        }
+    }
+}
+
+impl FromStr for FileConfig {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s
+        .strip_prefix("folder=")
+        .map(FileConfig::new)
+        .ok_or(format!("Invalid value for file config: {}", s))
+    }
+}
+
+impl<'de> Deserialize<'de> for FileConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de> {
+        
+        let s = String::deserialize(deserializer)?;
+
+        s
+        .parse()
+        .map_err(D::Error::custom)
+    }
+}
+
+impl std::fmt::Display for FileConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "folder={}", self.folder.as_str())
+    }
+}
+
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum StorageBackend {
+    File(FileConfig),
+    S3(S3Config),
+}
+
+impl StorageBackend {
+    pub fn file(config: FileConfig) -> Self {
+        Self::File(config)
+    }
+    pub fn s3(config: S3Config) -> Self {
+        Self::S3(config)
+    }
+
+    pub fn is_s3(&self) -> bool {
+        matches!(self, Self::S3(_))
+    }
+
+    pub fn is_file(&self) -> bool {
+        matches!(self, Self::File(_))
+    }
+
+    pub fn file_config(&self) -> Option<&FileConfig> {
+        match self {
+            Self::File(config) => Some(config),
+            Self::S3(_) => None
+        }
+    }
+    pub fn s3_config(&self) -> Option<&S3Config> {
+        match self {
+            Self::File(_) => None,
+            Self::S3(config) => Some(config)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StorageBackend {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de> {
+        
+        String::deserialize(deserializer)?
+        .parse()
+        .map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for StorageBackend {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer 
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+
+impl FromStr for StorageBackend {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+
+        if let Some(suffix) = s.strip_prefix("kind=file,") {
+            return Ok(
+                suffix
+                .parse::<FileConfig>()
+                .map(|config| Self::File(config))
+                .map_err(|err| format!("unable to parse file config: {err}"))?
+            );
+        }
+
+        if let Some(suffix) = s.strip_prefix("kind=s3,") {
+            return Ok(
+                suffix
+                .parse::<S3Config>()
+                .map(|config| Self::S3(config))
+                .map_err(|err| format!("unable to parse s3 config: {err}"))?
+            );
+        }
+        Err(format!("Invalid configuration for storage backend. should start with either kind=s3, or kind=file: '{s}'"))
+    }
+}
+
+impl std::fmt::Display for StorageBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::File(config) => {
+                write!(f, "kind=file,{}", config)
+            },
+            Self::S3(config) => {
+                write!(f, "kind=s3,{}", config)
+            }
+        }
+    }
+}
+
+
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, ClapSerde)]
+pub struct Storage {
+    #[default(StorageBackend::File(FileConfig::new("crates")))]
+    #[arg(id = "storage-kellnr-crates", long = "storage-kellnr-crates")]
+    pub kellnr_crates: StorageBackend,
+    #[default(StorageBackend::File(FileConfig::new("crates-io")))]
+    #[arg(id = "storage-crates-io", long = "storage-crates-io")]
+    pub crates_io: StorageBackend,
+    #[default(StorageBackend::File(FileConfig::new("toolchain")))]
+    #[arg(id = "storage-toolchain", long = "storage-toolchain")]
+    pub toolchain: StorageBackend,
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_serde() {
+        let toml = r#"
+            kellnr_crates = "kind=file,folder=foo"
+            crates_io = "kind=s3,access_key=foo,region=bar,endpoint=foo.com,secret_key=,bucket=baz,allow_http=false"
+        "#;
+        let storage: Storage = toml::from_str(&toml).unwrap();
+
+        let crates_io = storage.crates_io;
+        assert!(crates_io.is_s3());
+        let crates_io_config = crates_io.s3_config().unwrap();
+        assert_eq!(crates_io_config.access_key, Some("foo".to_string()));
+        assert_eq!(crates_io_config.secret_key, None);
+        assert_eq!(crates_io_config.region, Some("bar".to_string()));
+        assert_eq!(crates_io_config.endpoint, Some("foo.com".to_string()));
+        assert_eq!(crates_io_config.bucket, "baz".to_string());
+        assert!(!crates_io_config.allow_http);
+
+        let kellnr_crates = storage.kellnr_crates;
+        assert!(kellnr_crates.is_file());
+        let kellnr_crates_config = kellnr_crates.file_config().unwrap();
+        assert_eq!(kellnr_crates_config.folder, "foo".to_string());
+
+        assert!(storage.toolchain.is_file());
+        let toolchain_config = storage.toolchain.file_config().unwrap();
+        assert_eq!(toolchain_config.folder, "toolchain".to_string());
+    }
+
+    #[test]
+    fn test_storage_default() {
+        let storage: Storage = Default::default();
+        assert_eq!(storage.kellnr_crates.file_config().unwrap().folder, "crates".to_string());
+        assert_eq!(storage.crates_io.file_config().unwrap().folder, "crates-io".to_string());
+        assert_eq!(storage.toolchain.file_config().unwrap().folder, "toolchain".to_string());
+
+    }
+}

--- a/crates/storage/src/fs_storage.rs
+++ b/crates/storage/src/fs_storage.rs
@@ -2,6 +2,7 @@ use std::fs::DirBuilder;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use kellnr_settings::storage::FileConfig;
 use object_store::local::LocalFileSystem;
 use object_store::path::Path;
 use object_store::{ObjectStore, ObjectStoreExt, PutMode};
@@ -61,5 +62,13 @@ impl FSStorage {
 
     fn storage(&self) -> &LocalFileSystem {
         &self.0
+    }
+}
+
+
+impl TryFrom<&FileConfig> for FSStorage {
+    type Error = StorageError;
+    fn try_from(config: &FileConfig) -> Result<Self, Self::Error> {
+        Self::new(&config.folder)
     }
 }

--- a/crates/storage/src/s3_storage.rs
+++ b/crates/storage/src/s3_storage.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use bytes::Bytes;
-use kellnr_settings::Settings;
+use kellnr_settings::s3::S3Config;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path;
 use object_store::{ObjectStore, ObjectStoreExt, PutMode};
@@ -61,24 +61,25 @@ impl S3Storage {
     }
 }
 
-impl TryFrom<(&str, &Settings)> for S3Storage {
+impl TryFrom<&S3Config> for S3Storage {
     type Error = StorageError;
 
-    fn try_from((bucket, settings): (&str, &Settings)) -> Result<Self, Self::Error> {
+    fn try_from(config: &S3Config) -> Result<Self, Self::Error> {
+
         let mut s3 = AmazonS3Builder::from_env()
-            .with_bucket_name(bucket)
-            .with_allow_http(settings.s3.allow_http)
+            .with_bucket_name(&config.bucket)
+            .with_allow_http(config.allow_http)
             .with_conditional_put(object_store::aws::S3ConditionalPut::ETagMatch);
-        if let Some(endpoint) = &settings.s3.endpoint {
+        if let Some(endpoint) = &config.endpoint {
             s3 = s3.with_endpoint(endpoint);
         }
-        if let Some(region) = &settings.s3.region {
+        if let Some(region) = &config.region {
             s3 = s3.with_region(region);
         }
-        if let Some(access_key) = &settings.s3.access_key {
+        if let Some(access_key) = &config.access_key {
             s3 = s3.with_access_key_id(access_key);
         }
-        if let Some(secret_key) = &settings.s3.secret_key {
+        if let Some(secret_key) = &config.secret_key {
             s3 = s3.with_secret_access_key(secret_key);
         }
         // S3-compatible (RustFS, MinIO, etc.)

--- a/crates/storage/tests/s3_tests.rs
+++ b/crates/storage/tests/s3_tests.rs
@@ -6,7 +6,8 @@ use kellnr_common::publish_metadata::PublishMetadata;
 use kellnr_common::version::Version;
 use kellnr_rustfs_testcontainer::*;
 use kellnr_settings::Settings;
-use kellnr_settings::s3::S3;
+use kellnr_settings::storage::{Storage, StorageBackend};
+use kellnr_settings::s3::S3Config;
 use kellnr_storage::cached_crate_storage::DynStorage;
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 use kellnr_storage::s3_storage::S3Storage;
@@ -28,20 +29,24 @@ impl TestS3Storage {
                 admin_pwd: String::new(),
                 ..kellnr_settings::Setup::default()
             },
-            s3: S3 {
-                enabled: true,
-                access_key: Some("rustfsadmin".into()),
-                secret_key: Some("rustfsadmin".into()),
-                endpoint: Some(url.to_string()),
-                allow_http: true,
-                ..S3::default()
+            storage: Storage {
+                kellnr_crates: StorageBackend::S3(S3Config {
+                    access_key: Some("rustfsadmin".into()),
+                    secret_key: Some("rustfsadmin".into()),
+                    endpoint: Some(url.to_string()),
+                    allow_http: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
             },
             ..Settings::default()
         };
-        let storage =
-            Box::new(S3Storage::try_from(("kellnr-crates", &settings)).unwrap()) as DynStorage;
-        let crate_storage = KellnrCrateStorage::new(&settings, storage);
-        TestS3Storage { crate_storage }
+        // let storage =
+        //     Box::new(S3Storage::try_from(("kellnr-crates", &settings)).unwrap()) as DynStorage;
+        // let crate_storage = KellnrCrateStorage::new(&settings, storage);
+        let storage = S3Storage::try_from(settings.storage.kellnr_crates.s3_config().unwrap()).unwrap();
+        // let crate_storage = KellnrCrateStorage::new()
+        TestS3Storage { crate_storage: KellnrCrateStorage::new(&settings, Box::new(storage) as DynStorage) }
     }
 }
 

--- a/tests/src/ui-s3-storage.spec.ts
+++ b/tests/src/ui-s3-storage.spec.ts
@@ -124,13 +124,8 @@ test.describe("S3 Storage UI Tests", () => {
       name: `kellnr-s3-${suffix}`,
       env: {
         KELLNR_PROXY__ENABLED: "true",
-        KELLNR_S3__ENABLED: "true",
-        KELLNR_S3__ACCESS_KEY: s3RootUser,
-        KELLNR_S3__SECRET_KEY: s3RootPassword,
-        KELLNR_S3__ENDPOINT: s3UrlForLocalKellnr,
-        KELLNR_S3__ALLOW_HTTP: s3AllowHttp,
-        KELLNR_S3__CRATES_BUCKET: s3CratesBucket,
-        KELLNR_S3__CRATESIO_BUCKET: s3CratesioBucket,
+        KELLNR_STORAGE__KELLNR_CRATES: `kind=s3,access_key=${s3RootUser},secret_key=${s3RootPassword},endpoint=${s3UrlForLocalKellnr},allow_http=true,bucket=${s3CratesBucket}`,
+        KELLNR_STORAGE__CRATES_IO: `kind=s3,access_key=${s3RootUser},secret_key=${s3RootPassword},endpoint=${s3UrlForLocalKellnr},allow_http=true,bucket=${s3CratesioBucket}`,
       },
     });
 

--- a/tests/src/ui-toolchains-s3.spec.ts
+++ b/tests/src/ui-toolchains-s3.spec.ts
@@ -130,14 +130,9 @@ test.describe("Toolchain S3 Storage Tests", () => {
       env: {
         KELLNR_REGISTRY__AUTH_REQUIRED: "true",
         KELLNR_TOOLCHAIN__ENABLED: "true",
-        KELLNR_S3__ENABLED: "true",
-        KELLNR_S3__ACCESS_KEY: s3RootUser,
-        KELLNR_S3__SECRET_KEY: s3RootPassword,
-        KELLNR_S3__ENDPOINT: s3UrlForLocalKellnr,
-        KELLNR_S3__ALLOW_HTTP: "true",
-        KELLNR_S3__CRATES_BUCKET: s3CratesBucket,
-        KELLNR_S3__CRATESIO_BUCKET: s3CratesioBucket,
-        KELLNR_S3__TOOLCHAIN_BUCKET: s3ToolchainBucket,
+        KELLNR_STORAGE__KELLNR_CRATES: `kind=s3,access_key=${s3RootUser},secret_key=${s3RootPassword},endpoint=${s3UrlForLocalKellnr},allow_http=true,bucket=${s3CratesBucket}`,
+        KELLNR_STORAGE__CRATES_IO: `kind=s3,access_key=${s3RootUser},secret_key=${s3RootPassword},endpoint=${s3UrlForLocalKellnr},allow_http=true,bucket=${s3CratesioBucket}`,
+        KELLNR_STORAGE__TOOLCHAIN: `kind=s3,access_key=${s3RootUser},secret_key=${s3RootPassword},endpoint=${s3UrlForLocalKellnr},allow_http=true,bucket=${s3ToolchainBucket}`,
       },
     });
 

--- a/ui/src/components/StartupConfig.vue
+++ b/ui/src/components/StartupConfig.vue
@@ -195,20 +195,14 @@ const sections: ConfigSection[] = [
     ]
   },
   {
-    key: 's3',
-    title: 'S3 Storage',
-    icon: 'mdi-cloud-outline',
-    hasEnabledToggle: true,
+    key: 'storage',
+    title: 'Storage',
+    icon: 'mdi-file-document-outline',
+    hasEnabledToggle: false,
     items: [
-      { key: 's3.enabled', label: 'Enabled', type: 'boolean', cli: '--s3-enabled' },
-      { key: 's3.access_key', label: 'Access Key', cli: '--s3-access-key' },
-      { key: 's3.secret_key', label: 'Secret Key', secret: true, cli: '--s3-secret-key' },
-      { key: 's3.region', label: 'Region', cli: '--s3-region' },
-      { key: 's3.endpoint', label: 'Endpoint', cli: '--s3-endpoint' },
-      { key: 's3.allow_http', label: 'Allow HTTP', type: 'boolean', warningWhenTrue: true, cli: '--s3-allow-http' },
-      { key: 's3.crates_bucket', label: 'Crates Bucket', cli: '--s3-crates-bucket' },
-      { key: 's3.cratesio_bucket', label: 'Crates.io Bucket', cli: '--s3-cratesio-bucket' },
-      { key: 's3.toolchain_bucket', label: 'Toolchain Bucket', cli: '--s3-toolchain-bucket' },
+      { key: 'storage.kellnr_crates', label: 'Kellnr Crates', cli: '--storage-kellnr-crates' },
+      { key: 'storage.crates_io', label: 'Crates.io', cli: '--storage-crates-io' },
+      { key: 'storage.toolchain', label: 'Toolchain', cli: '--storage-toolchain' },
     ]
   },
   {

--- a/ui/src/types/settings.ts
+++ b/ui/src/types/settings.ts
@@ -19,7 +19,7 @@ export type SettingsDefaults = {
   postgresql: Postgresql
   proxy: Proxy
   registry: Registry
-  s3: S3
+  storage: Storage
   toolchain: Toolchain
 }
 
@@ -31,7 +31,7 @@ export type Settings = {
   postgresql: Postgresql
   proxy: Proxy
   registry: Registry
-  s3: S3
+  storage: Storage
   toolchain: Toolchain
   sources: SourceMap
   defaults?: SettingsDefaults
@@ -99,16 +99,27 @@ export type Registry = {
   token_db_retry_delay_ms: number
 }
 
-export type S3 = {
-  enabled: boolean
+export type Storage = {
+  kellnr_crates: StorageBackend | null
+  crates_io: StorageBackend | null
+  toolchain: StorageBackend | null
+}
+
+export type StorageBackend = FileBackend | S3Backend;
+
+export type FileBackend = {
+  kind: 'file'
+  folder: string
+}
+
+export type S3Backend = {
+  kind: 's3'
+  bucket: string
   access_key: string | null
   secret_key: string | null
   region: string | null
   endpoint: string | null
   allow_http: boolean
-  crates_bucket: string
-  cratesio_bucket: string
-  toolchain_bucket: string
 }
 
 export const emptySettings: Settings = {
@@ -162,16 +173,16 @@ export const emptySettings: Settings = {
     token_db_retry_count: 3,
     token_db_retry_delay_ms: 100
   },
-  s3: {
-    enabled: false,
-    access_key: null,
-    secret_key: null,
-    region: null,
-    endpoint: null,
-    allow_http: false,
-    crates_bucket: "",
-    cratesio_bucket: "",
-    toolchain_bucket: ""
+  storage: {
+    kellnr_crates: {
+      kind: 'file',
+      folder: 'crates'
+    },
+    crates_io: {
+      kind: 'file',
+      folder: 'crates-io'
+    },
+    toolchain: null
   },
   toolchain: {
     enabled: false,


### PR DESCRIPTION
Consider a scenario where a S3 service is running on HDDs, but the server infra is running on SSDs. Here it might make sense to have a split storage, i.e. the registry-owned crates would be persisted in a robust (but possibly slow) s3-compatible storage while any proxied crates can be cached locally on the same filesystem as the server for quick downloads.

I happen to run into this hardware configuration, so I took a chance at implementing this split storage configuration.

I'm open to ideas/suggestions that would improve this PR and hopefully be a valuable feature addition to Kellnr.

Thanks for all your amazing work in building and maintaining Kellnr.