### PR TITLE
chore: release v6.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "cargo",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "bytes",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "async-std",
  "chrono",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "bytes",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.1.0"
+version = "6.1.1"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.1.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.1.0", path = "./crates/auth" }
-kellnr-common = { version = "6.1.0", path = "./crates/common" }
-kellnr-db = { version = "6.1.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.1.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.1.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.1.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.1.0", path = "./crates/error" }
-kellnr-index = { version = "6.1.0", path = "./crates/index" }
-kellnr-migration = { version = "6.1.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.1.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.1.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.1.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.1.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.1.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.1.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.1.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.1.1", path = "./crates/appstate" }
+kellnr-auth = { version = "6.1.1", path = "./crates/auth" }
+kellnr-common = { version = "6.1.1", path = "./crates/common" }
+kellnr-db = { version = "6.1.1", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.1.1", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.1.1", path = "./crates/docs" }
+kellnr-entity = { version = "6.1.1", path = "./crates/db/entity" }
+kellnr-error = { version = "6.1.1", path = "./crates/error" }
+kellnr-index = { version = "6.1.1", path = "./crates/index" }
+kellnr-migration = { version = "6.1.1", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.1.1", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.1.1", path = "./crates/registry" }
+kellnr-settings = { version = "6.1.1", path = "./crates/settings" }
+kellnr-storage = { version = "6.1.1", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.1.1", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.1.1", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.1.1", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.1.1

This release updates all workspace packages to version **6.1.1**.

<details><summary><i><b>Changelog</b></i></summary>

## [6.1.1](https://github.com/kellnr/kellnr/compare/v6.1.0...v6.1.1) - 2026-04-01

### Fixed

- reset password UI validation issue [#1144](https://github.com/kellnr/kellnr/issues/1144)
- fix oath autocreate username problem [#1135](https://github.com/kellnr/kellnr/pull/1135)

---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
