### PR TITLE
chore: release v6.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "cargo",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "bytes",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.2.0"
+version = "6.3.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.2.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.2.0", path = "./crates/auth" }
-kellnr-common = { version = "6.2.0", path = "./crates/common" }
-kellnr-db = { version = "6.2.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.2.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.2.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.2.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.2.0", path = "./crates/error" }
-kellnr-index = { version = "6.2.0", path = "./crates/index" }
-kellnr-migration = { version = "6.2.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.2.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.2.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.2.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.2.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.2.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.2.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.2.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.3.0", path = "./crates/appstate" }
+kellnr-auth = { version = "6.3.0", path = "./crates/auth" }
+kellnr-common = { version = "6.3.0", path = "./crates/common" }
+kellnr-db = { version = "6.3.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.3.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.3.0", path = "./crates/docs" }
+kellnr-entity = { version = "6.3.0", path = "./crates/db/entity" }
+kellnr-error = { version = "6.3.0", path = "./crates/error" }
+kellnr-index = { version = "6.3.0", path = "./crates/index" }
+kellnr-migration = { version = "6.3.0", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.3.0", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.3.0", path = "./crates/registry" }
+kellnr-settings = { version = "6.3.0", path = "./crates/settings" }
+kellnr-storage = { version = "6.3.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.3.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.3.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.3.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.3.0

This release updates all workspace packages to version **6.3.0**.

<details><summary><i><b>Changelog</b></i></summary>

## [6.3.0](https://github.com/kellnr/kellnr/compare/v6.2.0...v6.3.0) - 2026-04-18

### Added

- add proxy.api setting #1179

</details>


---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
