### PR TITLE
chore: release v6.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "cargo",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "bytes",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "async-std",
  "chrono",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "bytes",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "cargo",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.3.0"
+version = "6.3.1"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.3.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.3.0", path = "./crates/auth" }
-kellnr-common = { version = "6.3.0", path = "./crates/common" }
-kellnr-db = { version = "6.3.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.3.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.3.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.3.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.3.0", path = "./crates/error" }
-kellnr-index = { version = "6.3.0", path = "./crates/index" }
-kellnr-migration = { version = "6.3.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.3.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.3.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.3.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.3.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.3.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.3.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.3.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.3.1", path = "./crates/appstate" }
+kellnr-auth = { version = "6.3.1", path = "./crates/auth" }
+kellnr-common = { version = "6.3.1", path = "./crates/common" }
+kellnr-db = { version = "6.3.1", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.3.1", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.3.1", path = "./crates/docs" }
+kellnr-entity = { version = "6.3.1", path = "./crates/db/entity" }
+kellnr-error = { version = "6.3.1", path = "./crates/error" }
+kellnr-index = { version = "6.3.1", path = "./crates/index" }
+kellnr-migration = { version = "6.3.1", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.3.1", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.3.1", path = "./crates/registry" }
+kellnr-settings = { version = "6.3.1", path = "./crates/settings" }
+kellnr-storage = { version = "6.3.1", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.3.1", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.3.1", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.3.1", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.3.0"
+version = "6.4.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.3.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.3.0", path = "./crates/auth" }
-kellnr-common = { version = "6.3.0", path = "./crates/common" }
-kellnr-db = { version = "6.3.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.3.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.3.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.3.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.3.0", path = "./crates/error" }
-kellnr-index = { version = "6.3.0", path = "./crates/index" }
-kellnr-migration = { version = "6.3.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.3.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.3.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.3.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.3.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.3.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.3.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.3.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.4.0", path = "./crates/appstate" }
+kellnr-auth = { version = "6.4.0", path = "./crates/auth" }
+kellnr-common = { version = "6.4.0", path = "./crates/common" }
+kellnr-db = { version = "6.4.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.4.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.4.0", path = "./crates/docs" }
+kellnr-entity = { version = "6.4.0", path = "./crates/db/entity" }
+kellnr-error = { version = "6.4.0", path = "./crates/error" }
+kellnr-index = { version = "6.4.0", path = "./crates/index" }
+kellnr-migration = { version = "6.4.0", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.4.0", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.4.0", path = "./crates/registry" }
+kellnr-settings = { version = "6.4.0", path = "./crates/settings" }
+kellnr-storage = { version = "6.4.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.4.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.4.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.4.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.4.0

This release updates all workspace packages to version **6.4.0**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-rustfs-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [6.4.0](https://github.com/kellnr/kellnr/compare/v6.3.0...v6.4.0) - 2026-06-12

### Added

- add setting to set user agent #1223

### Fixed

- improve get_crate_data performance by grouping dep desc queries ([#1235](https://github.com/kellnr/kellnr/pull/1235))
- use proxy correctly in cargo docs generation #1185
- rust-toolchain.toml wrongly taken into account #1176
- formatting

### Other

- update sqlx and cargo crates ([#1236](https://github.com/kellnr/kellnr/pull/1236))
- *(deps)* bump the npm-all group in /ui with 9 updates ([#1234](https://github.com/kellnr/kellnr/pull/1234))
- *(deps)* bump chrono from 0.4.44 to 0.4.45 ([#1233](https://github.com/kellnr/kellnr/pull/1233))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump the npm-all group in /ui with 9 updates
- *(deps)* bump chrono from 0.4.44 to 0.4.45
- *(deps)* bump the npm-all group in /ui with 9 updates ([#1228](https://github.com/kellnr/kellnr/pull/1228))
- *(deps)* bump hyper from 1.9.0 to 1.10.1 ([#1226](https://github.com/kellnr/kellnr/pull/1226))
- *(deps)* bump reqwest from 0.13.3 to 0.13.4 ([#1229](https://github.com/kellnr/kellnr/pull/1229))
- *(deps)* bump uuid from 1.23.1 to 1.23.2 ([#1227](https://github.com/kellnr/kellnr/pull/1227))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump reqwest from 0.13.3 to 0.13.4
- *(deps)* bump the npm-all group in /ui with 9 updates
- *(deps)* bump uuid from 1.23.1 to 1.23.2
- *(deps)* bump hyper from 1.9.0 to 1.10.1
- *(deps)* bump astral-tokio-tar from 0.6.1 to 0.6.2 ([#1225](https://github.com/kellnr/kellnr/pull/1225))
- *(deps)* bump astral-tokio-tar from 0.6.1 to 0.6.2
- *(deps-dev)* bump tmp from 0.2.5 to 0.2.7 in /tests ([#1222](https://github.com/kellnr/kellnr/pull/1222))
- *(deps-dev)* bump tmp from 0.2.5 to 0.2.7 in /tests
- *(deps)* bump the npm-all group in /ui with 6 updates ([#1215](https://github.com/kellnr/kellnr/pull/1215))
- *(deps)* bump openssl from 0.10.79 to 0.10.80 ([#1214](https://github.com/kellnr/kellnr/pull/1214))
- *(deps)* bump uuid and testcontainers in /tests ([#1219](https://github.com/kellnr/kellnr/pull/1219))
- *(deps)* bump tower-http from 0.6.10 to 0.6.11 ([#1217](https://github.com/kellnr/kellnr/pull/1217))
- *(deps)* bump tar from 0.4.45 to 0.4.46 ([#1218](https://github.com/kellnr/kellnr/pull/1218))
- *(deps)* bump openssl from 0.10.79 to 0.10.80 ([#1221](https://github.com/kellnr/kellnr/pull/1221))
- *(deps)* bump serde_json from 1.0.149 to 1.0.150 ([#1216](https://github.com/kellnr/kellnr/pull/1216))
- Merge branch 'main' into dependabot/cargo/main/openssl-0.10.80
- Merge branch 'main' into dependabot/npm_and_yarn/ui/main/npm-all-921112e3fd
- Merge branch 'main' into dependabot/cargo/main/tower-http-0.6.11
- Merge branch 'main' into dependabot/cargo/main/tar-0.4.46
- Merge branch 'main' into dependabot/npm_and_yarn/tests/multi-00b3af1e76
- *(deps)* bump serde_json from 1.0.149 to 1.0.150
- *(deps)* bump openssl from 0.10.79 to 0.10.80
- use "provcfg" instead of "config" crate ([#1220](https://github.com/kellnr/kellnr/pull/1220))
- *(deps)* bump uuid and testcontainers in /tests
- *(deps)* bump tar from 0.4.45 to 0.4.46
- *(deps)* bump tower-http from 0.6.10 to 0.6.11
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump the npm-all group in /ui with 6 updates
- *(deps)* bump openssl from 0.10.79 to 0.10.80
- update sea-orm
- update rnd crate
- add check for playwright version mismatch
- *(deps)* bump the npm-all group in /ui with 10 updates ([#1213](https://github.com/kellnr/kellnr/pull/1213))
- *(deps)* bump config from 0.15.22 to 0.15.23 ([#1212](https://github.com/kellnr/kellnr/pull/1212))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump the npm-all group in /ui with 10 updates
- *(deps)* bump config from 0.15.22 to 0.15.23
- *(deps-dev)* bump protobufjs from 7.5.5 to 7.5.8 in /tests ([#1209](https://github.com/kellnr/kellnr/pull/1209))
- *(deps-dev)* bump protobufjs from 7.5.5 to 7.5.8 in /tests
- *(deps-dev)* bump @protobufjs/utf8 from 1.1.0 to 1.1.1 in /tests ([#1208](https://github.com/kellnr/kellnr/pull/1208))
- *(deps-dev)* bump @protobufjs/utf8 from 1.1.0 to 1.1.1 in /tests
- *(deps)* bump the npm-all group in /ui with 8 updates ([#1205](https://github.com/kellnr/kellnr/pull/1205))
- *(deps)* bump tower-http from 0.6.8 to 0.6.10 ([#1207](https://github.com/kellnr/kellnr/pull/1207))
- *(deps)* bump utoipa from 5.4.0 to 5.5.0 ([#1206](https://github.com/kellnr/kellnr/pull/1206))
- *(deps)* bump tokio from 1.52.1 to 1.52.3 ([#1204](https://github.com/kellnr/kellnr/pull/1204))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump tower-http from 0.6.8 to 0.6.10
- *(deps)* bump utoipa from 5.4.0 to 5.5.0
- *(deps)* bump the npm-all group in /ui with 8 updates
- *(deps)* bump tokio from 1.52.1 to 1.52.3
- *(deps)* bump astral-tokio-tar from 0.6.0 to 0.6.1 ([#1203](https://github.com/kellnr/kellnr/pull/1203))
- *(deps)* bump astral-tokio-tar from 0.6.0 to 0.6.1
- *(deps)* bump openssl from 0.10.78 to 0.10.79 ([#1202](https://github.com/kellnr/kellnr/pull/1202))
- *(deps)* bump openssl from 0.10.78 to 0.10.79
- *(deps)* bump the npm-all group in /ui with 5 updates ([#1199](https://github.com/kellnr/kellnr/pull/1199))
- *(deps)* bump reqwest from 0.13.2 to 0.13.3 ([#1200](https://github.com/kellnr/kellnr/pull/1200))
- *(deps)* bump tokio from 1.51.1 to 1.52.1 ([#1201](https://github.com/kellnr/kellnr/pull/1201))
- *(deps)* bump zip from 8.5.1 to 8.6.0 ([#1198](https://github.com/kellnr/kellnr/pull/1198))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump tokio from 1.51.1 to 1.52.1
- *(deps)* bump reqwest from 0.13.2 to 0.13.3
- *(deps)* bump the npm-all group in /ui with 5 updates
- *(deps)* bump zip from 8.5.1 to 8.6.0
- *(deps)* bump clap from 4.5.60 to 4.6.1 ([#1195](https://github.com/kellnr/kellnr/pull/1195))
- *(deps)* bump axum-extra from 0.12.5 to 0.12.6 ([#1196](https://github.com/kellnr/kellnr/pull/1196))
- *(deps)* bump the npm-all group in /ui with 10 updates ([#1194](https://github.com/kellnr/kellnr/pull/1194))
- *(deps)* bump testcontainers from 0.27.2 to 0.27.3 ([#1197](https://github.com/kellnr/kellnr/pull/1197))
- *(deps)* bump clap from 4.5.60 to 4.6.1
- *(deps)* bump axum-extra from 0.12.5 to 0.12.6
- *(deps)* bump axum from 0.8.8 to 0.8.9 ([#1192](https://github.com/kellnr/kellnr/pull/1192))
- *(deps)* bump uuid from 1.23.0 to 1.23.1 ([#1193](https://github.com/kellnr/kellnr/pull/1193))
- *(deps)* bump dependabot/fetch-metadata from 3.0.0 to 3.1.0 ([#1191](https://github.com/kellnr/kellnr/pull/1191))
- *(deps)* bump testcontainers from 0.27.2 to 0.27.3
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump the npm-all group in /ui with 10 updates
- *(deps)* bump uuid from 1.23.0 to 1.23.1
- *(deps)* bump axum from 0.8.8 to 0.8.9
- *(deps)* bump dependabot/fetch-metadata from 3.0.0 to 3.1.0
- *(deps)* bump postcss from 8.5.8 to 8.5.10 in /ui ([#1190](https://github.com/kellnr/kellnr/pull/1190))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump postcss from 8.5.8 to 8.5.10 in /ui
- *(deps)* bump rustls-webpki from 0.103.10 to 0.103.13 ([#1189](https://github.com/kellnr/kellnr/pull/1189))
- *(deps)* bump rustls-webpki from 0.103.10 to 0.103.13
- *(deps)* bump openssl from 0.10.75 to 0.10.78 ([#1188](https://github.com/kellnr/kellnr/pull/1188))
- *(deps)* bump openssl from 0.10.75 to 0.10.78
- update cargo dep to latest version #1186
- Merge branch 'main' into chore/update-cargo-dep
- update cargo dep to latest version #1186

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
