### PR TITLE
fix: improve get_crate_data performance by grouping dep desc queries

### DIFF
--- a/crates/common/src/index_metadata.rs
+++ b/crates/common/src/index_metadata.rs
@@ -232,7 +232,7 @@ impl IndexMetadata {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IndexDep {
     // Name of the dependency.
     // If the dependency is renamed from the original package name,
@@ -270,7 +270,7 @@ pub struct IndexDep {
     pub package: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub enum DependencyKind {
     Normal,
     Build,

--- a/crates/common/src/index_metadata.rs
+++ b/crates/common/src/index_metadata.rs
@@ -232,7 +232,7 @@ impl IndexMetadata {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct IndexDep {
     // Name of the dependency.
     // If the dependency is renamed from the original package name,
@@ -270,7 +270,7 @@ pub struct IndexDep {
     pub package: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum DependencyKind {
     Normal,
     Build,

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -1366,15 +1366,13 @@ impl DbProvider for Database {
                         .map_err(|e| DbError::FailedToConvertToJson(e.to_string()))?;
 
                     let mut ft = Vec::new();
-                    for dep in ix {
+
+                    let dep_descs = operations::get_desc_for_deps(&self.db_con, ix.iter()).await?;
+
+                    for dep in &ix {
                         ft.push(CrateRegistryDep::from_index(
-                            operations::get_desc_for_crate_dep(
-                                &self.db_con,
-                                &dep.name,
-                                dep.registry.as_deref(),
-                            )
-                            .await?,
-                            dep,
+                            dep_descs.get(&dep).cloned(),
+                            dep.clone(),
                         ));
                     }
 

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -1371,7 +1371,7 @@ impl DbProvider for Database {
 
                     for dep in &ix {
                         ft.push(CrateRegistryDep::from_index(
-                            dep_descs.get(&dep).cloned(),
+                            dep_descs.get(&dep.name).cloned(),
                             dep.clone(),
                         ));
                     }

--- a/crates/db/src/database/operations.rs
+++ b/crates/db/src/database/operations.rs
@@ -23,27 +23,13 @@ use crate::error::DbError;
 use crate::password::{hash_pwd, hash_token};
 use crate::provider::DbResult;
 
-pub async fn get_desc_for_deps<'a, C, D>(
-    db_con: &C,
-    deps: D,
-) -> DbResult<HashMap<&'a IndexDep, String>>
+pub async fn get_desc_for_deps<'a, C, D>(db_con: &C, deps: D) -> DbResult<HashMap<String, String>>
 where
     C: ConnectionTrait,
     D: Iterator<Item = &'a IndexDep>,
 {
-    fn descriptions_by_dep<'a>(
-        models: impl IntoIterator<Item = (String, Option<String>)>,
-        deps: &[&'a IndexDep],
-    ) -> impl Iterator<Item = (&'a IndexDep, String)> {
-        models.into_iter().filter_map(move |(name, description)| {
-            let description = description?;
-            let dep = *deps.iter().find(|d| d.name == name)?;
-            Some((dep, description))
-        })
-    }
-
-    let mut crates = Vec::new();
     let mut cratesio_crates = Vec::new();
+    let mut crates = Vec::new();
 
     for dep in deps {
         match dep.registry.as_ref() {
@@ -63,17 +49,14 @@ where
         .all(db_con)
         .await?;
 
-    let res = descriptions_by_dep(
-        cratesio_models.into_iter().map(|m| (m.name, m.description)),
-        &cratesio_crates,
-    )
-    .chain(descriptions_by_dep(
-        models.into_iter().map(|m| (m.name, m.description)),
-        &crates,
-    ))
-    .collect();
+    let cratesio_desc = cratesio_models
+        .into_iter()
+        .filter_map(|m| Some((m.name, m.description?)));
+    let local_desc = models
+        .into_iter()
+        .filter_map(|m| Some((m.name, m.description?)));
 
-    Ok(res)
+    Ok(cratesio_desc.chain(local_desc).collect())
 }
 
 pub async fn insert_admin_credentials<C: ConnectionTrait>(

--- a/crates/db/src/database/operations.rs
+++ b/crates/db/src/database/operations.rs
@@ -4,7 +4,9 @@
 //! specific operations. Used by the Database impl to keep the main module
 //! focused on the `DbProvider` trait implementation.
 
-use kellnr_common::index_metadata::IndexMetadata;
+use std::collections::HashMap;
+
+use kellnr_common::index_metadata::{IndexDep, IndexMetadata};
 use kellnr_common::normalized_name::NormalizedName;
 use kellnr_common::publish_metadata::PublishMetadata;
 use kellnr_entity::{
@@ -21,28 +23,57 @@ use crate::error::DbError;
 use crate::password::{hash_pwd, hash_token};
 use crate::provider::DbResult;
 
-pub async fn get_desc_for_crate_dep<C: ConnectionTrait>(
+pub async fn get_desc_for_deps<'a, C, D>(
     db_con: &C,
-    name: &str,
-    registry: Option<&str>,
-) -> DbResult<Option<String>> {
-    let desc = if registry.unwrap_or_default() == "https://github.com/rust-lang/crates.io-index" {
-        let krate = cratesio_crate::Entity::find()
-            .filter(cratesio_crate::Column::Name.eq(name))
-            .one(db_con)
-            .await?;
-        krate.and_then(|krate| krate.description)
-    } else {
-        // Not a crates.io dependency.
-        // We cannot know that the crate is from this kellnr instance, but we give it a try.
-        let krate = krate::Entity::find()
-            .filter(krate::Column::Name.eq(name))
-            .one(db_con)
-            .await?;
-        krate.and_then(|krate| krate.description)
-    };
+    deps: D,
+) -> DbResult<HashMap<&'a IndexDep, String>>
+where
+    C: ConnectionTrait,
+    D: Iterator<Item = &'a IndexDep>,
+{
+    fn descriptions_by_dep<'a>(
+        models: impl IntoIterator<Item = (String, Option<String>)>,
+        deps: &[&'a IndexDep],
+    ) -> impl Iterator<Item = (&'a IndexDep, String)> {
+        models.into_iter().filter_map(move |(name, description)| {
+            let description = description?;
+            let dep = *deps.iter().find(|d| d.name == name)?;
+            Some((dep, description))
+        })
+    }
 
-    Ok(desc)
+    let mut crates = Vec::new();
+    let mut cratesio_crates = Vec::new();
+
+    for dep in deps {
+        match dep.registry.as_ref() {
+            Some(r) if r == "https://github.com/rust-lang/crates.io-index" => {
+                cratesio_crates.push(dep);
+            }
+            _ => crates.push(dep),
+        }
+    }
+
+    let cratesio_models = cratesio_crate::Entity::find()
+        .filter(cratesio_crate::Column::Name.is_in(cratesio_crates.iter().map(|d| &d.name)))
+        .all(db_con)
+        .await?;
+    let models = krate::Entity::find()
+        .filter(krate::Column::Name.is_in(crates.iter().map(|d| &d.name)))
+        .all(db_con)
+        .await?;
+
+    let res = descriptions_by_dep(
+        cratesio_models.into_iter().map(|m| (m.name, m.description)),
+        &cratesio_crates,
+    )
+    .chain(descriptions_by_dep(
+        models.into_iter().map(|m| (m.name, m.description)),
+        &crates,
+    ))
+    .collect();
+
+    Ok(res)
 }
 
 pub async fn insert_admin_credentials<C: ConnectionTrait>(


### PR DESCRIPTION
`get_crate_data` loops over every crate meta then every dependency of that, then performs a query for every dependency, causing massive slowdowns when a crate has many dependencies and versions.

This (partially) solves that by grouping queries over `IndexDep`s. It still makes a query for every published crate version, but still provides a big improvement in loading times for crates with many dependencies.

Ideally the `/crate_data` endpoint should return a less verbose dataset, but that would be a breaking API change.