### PR TITLE
chore: release v6.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "cargo",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4391,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.4.0"
+version = "6.5.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.4.0"
+version = "6.5.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.4.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.4.0", path = "./crates/auth" }
-kellnr-common = { version = "6.4.0", path = "./crates/common" }
-kellnr-db = { version = "6.4.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.4.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.4.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.4.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.4.0", path = "./crates/error" }
-kellnr-index = { version = "6.4.0", path = "./crates/index" }
-kellnr-migration = { version = "6.4.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.4.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.4.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.4.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.4.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.4.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.4.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.4.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.5.0", path = "./crates/appstate" }
+kellnr-auth = { version = "6.5.0", path = "./crates/auth" }
+kellnr-common = { version = "6.5.0", path = "./crates/common" }
+kellnr-db = { version = "6.5.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.5.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.5.0", path = "./crates/docs" }
+kellnr-entity = { version = "6.5.0", path = "./crates/db/entity" }
+kellnr-error = { version = "6.5.0", path = "./crates/error" }
+kellnr-index = { version = "6.5.0", path = "./crates/index" }
+kellnr-migration = { version = "6.5.0", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.5.0", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.5.0", path = "./crates/registry" }
+kellnr-settings = { version = "6.5.0", path = "./crates/settings" }
+kellnr-storage = { version = "6.5.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.5.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.5.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.5.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.5.0

This release updates all workspace packages to version **6.5.0**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-rustfs-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [6.5.0](https://github.com/kellnr/kellnr/compare/v6.4.0...v6.5.0) - 2026-06-25

### Added

- *(auth)* expire sessions server-side and clean up old rows ([#1245](https://github.com/kellnr/kellnr/pull/1245))

### Fixed

- sparse index responses must end with a trailing newline ([#1247](https://github.com/kellnr/kellnr/pull/1247))
- *(auth)* harden session expiry edge cases ([#1246](https://github.com/kellnr/kellnr/pull/1246))
- *(oauth2)* re-sync admin/read-only state from IdP on each login ([#1244](https://github.com/kellnr/kellnr/pull/1244))
- *(auth)* enforce read-only state for session-authenticated users ([#1243](https://github.com/kellnr/kellnr/pull/1243))

### Other

- *(deps)* bump sea-orm from 2.0.0-rc.40 to 2.0.0-rc.41 ([#1252](https://github.com/kellnr/kellnr/pull/1252))
- *(deps-dev)* bump undici from 7.25.0 to 7.28.0 in /tests ([#1257](https://github.com/kellnr/kellnr/pull/1257))
- *(deps-dev)* bump undici from 7.25.0 to 7.28.0 in /tests
- *(deps)* bump form-data from 4.0.5 to 4.0.6 in /ui ([#1255](https://github.com/kellnr/kellnr/pull/1255))
- *(deps)* bump time from 0.3.47 to 0.3.49 ([#1254](https://github.com/kellnr/kellnr/pull/1254))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump form-data from 4.0.5 to 4.0.6 in /ui
- *(deps)* bump time from 0.3.47 to 0.3.49
- *(deps)* bump the npm-all group in /ui with 5 updates ([#1250](https://github.com/kellnr/kellnr/pull/1250))
- *(deps)* bump syn from 2.0.117 to 2.0.118 ([#1253](https://github.com/kellnr/kellnr/pull/1253))
- *(deps)* bump bytes from 1.11.1 to 1.12.0 ([#1249](https://github.com/kellnr/kellnr/pull/1249))
- *(deps)* bump tower-http from 0.6.11 to 0.7.0 ([#1251](https://github.com/kellnr/kellnr/pull/1251))
- *(deps)* bump actions/checkout from 6 to 7 ([#1248](https://github.com/kellnr/kellnr/pull/1248))
- *(deps)* bump syn from 2.0.117 to 2.0.118
- *(deps)* bump sea-orm from 2.0.0-rc.40 to 2.0.0-rc.41
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump tower-http from 0.6.11 to 0.7.0
- *(deps)* bump the npm-all group in /ui with 5 updates
- *(deps)* bump bytes from 1.11.1 to 1.12.0
- *(deps)* bump actions/checkout from 6 to 7
- *(deps)* bump the npm-all group in /ui with 7 updates ([#1240](https://github.com/kellnr/kellnr/pull/1240))
- *(deps)* bump regex from 1.12.3 to 1.12.4 ([#1242](https://github.com/kellnr/kellnr/pull/1242))
- *(deps)* bump openssl from 0.10.80 to 0.10.81 ([#1239](https://github.com/kellnr/kellnr/pull/1239))
- *(deps)* bump uuid from 1.23.2 to 1.23.3 ([#1241](https://github.com/kellnr/kellnr/pull/1241))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump regex from 1.12.3 to 1.12.4
- *(deps)* bump uuid from 1.23.2 to 1.23.3
- *(deps)* bump the npm-all group in /ui with 7 updates
- *(deps)* bump openssl from 0.10.80 to 0.10.81
- *(deps-dev)* bump esbuild from 0.28.0 to 0.28.1 in /ui ([#1238](https://github.com/kellnr/kellnr/pull/1238))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps-dev)* bump esbuild from 0.28.0 to 0.28.1 in /ui

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
