### PR TITLE
fix(auth): enforce read-only state for session-authenticated users

### DIFF
--- a/crates/auth/src/maybe_user.rs
+++ b/crates/auth/src/maybe_user.rs
@@ -4,6 +4,7 @@ use axum::http::StatusCode;
 use axum::http::request::Parts;
 use axum_extra::extract::PrivateCookieJar;
 use kellnr_appstate::AppStateData;
+use kellnr_db::SessionInfo;
 use kellnr_settings::constants;
 
 use crate::token;
@@ -24,13 +25,11 @@ impl MaybeUser {
         }
     }
 
-    pub fn from_session(name: String, is_admin: bool) -> Self {
+    pub fn from_session(session: SessionInfo) -> Self {
         Self {
-            name,
-            is_admin,
-            // Session auth does not currently expose read-only state.
-            // Treat as not read-only for API actions.
-            is_read_only: false,
+            name: session.name,
+            is_admin: session.is_admin,
+            is_read_only: session.is_read_only,
         }
     }
 }
@@ -57,12 +56,12 @@ impl FromRequestParts<AppStateData> for MaybeUser {
             .get(constants::COOKIE_SESSION_ID)
             .ok_or(StatusCode::UNAUTHORIZED)?;
 
-        let (name, is_admin) = state
+        let session = state
             .db
             .validate_session(session_cookie.value())
             .await
             .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-        Ok(Self::from_session(name, is_admin))
+        Ok(Self::from_session(session))
     }
 }

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -39,7 +39,7 @@ use sea_orm::{
 use crate::error::DbError;
 use crate::password::{generate_salt, hash_pwd, hash_token};
 use crate::provider::{
-    ChannelInfo, DbResult, OAuth2StateData, PrefetchState, ToolchainComponentInfo,
+    ChannelInfo, DbResult, OAuth2StateData, PrefetchState, SessionInfo, ToolchainComponentInfo,
     ToolchainTargetInfo, ToolchainWithTargets,
 };
 use crate::tables::init_database;
@@ -676,7 +676,7 @@ impl DbProvider for Database {
         }
     }
 
-    async fn validate_session(&self, session_token: &str) -> DbResult<(String, bool)> {
+    async fn validate_session(&self, session_token: &str) -> DbResult<SessionInfo> {
         let u = user::Entity::find()
             .join(JoinType::InnerJoin, user::Relation::Session.def())
             .filter(session::Column::Token.eq(session_token))
@@ -684,7 +684,11 @@ impl DbProvider for Database {
             .await?
             .ok_or(DbError::SessionNotFound)?;
 
-        Ok((u.name, u.is_admin))
+        Ok(SessionInfo {
+            name: u.name,
+            is_admin: u.is_admin,
+            is_read_only: u.is_read_only,
+        })
     }
 
     async fn add_session_token(&self, name: &str, session_token: &str) -> DbResult<()> {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -22,8 +22,8 @@ pub use doc_queue_entry::DocQueueEntry;
 pub use group::Group;
 pub use krate::Crate;
 pub use provider::{
-    ChannelInfo, DbProvider, OAuth2StateData, ToolchainComponentInfo, ToolchainTargetInfo,
-    ToolchainWithTargets, mock,
+    ChannelInfo, DbProvider, OAuth2StateData, SessionInfo, ToolchainComponentInfo,
+    ToolchainTargetInfo, ToolchainWithTargets, mock,
 };
 pub use user::User;
 

--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -27,6 +27,14 @@ pub enum PrefetchState {
     NotFound,
 }
 
+/// Authenticated user and privileges resolved from a valid session cookie.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionInfo {
+    pub name: String,
+    pub is_admin: bool,
+    pub is_read_only: bool,
+}
+
 /// Data stored during `OAuth2` authentication flow for CSRF/PKCE verification
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OAuth2StateData {
@@ -134,7 +142,7 @@ pub trait DbProvider: Send + Sync {
         crate_version: &Version,
         count: u64,
     ) -> DbResult<()>;
-    async fn validate_session(&self, session_token: &str) -> DbResult<(String, bool)>;
+    async fn validate_session(&self, session_token: &str) -> DbResult<SessionInfo>;
     async fn add_session_token(&self, name: &str, session_token: &str) -> DbResult<()>;
     async fn add_crate_user(&self, crate_name: &NormalizedName, user: &str) -> DbResult<()>;
     async fn add_owner(&self, crate_name: &NormalizedName, owner: &str) -> DbResult<()>;
@@ -450,7 +458,7 @@ pub mod mock {
                 unimplemented!()
             }
 
-            async fn validate_session(&self, _session_token: &str) -> DbResult<(String, bool)> {
+            async fn validate_session(&self, _session_token: &str) -> DbResult<SessionInfo> {
                 unimplemented!()
             }
 

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -949,8 +949,8 @@ async fn clean_db_after_time(test_db: &kellnr_db::Database) {
         .add_session_token("admin", "session_token")
         .await
         .unwrap();
-    let (name, _) = test_db.validate_session("session_token").await.unwrap();
-    assert_eq!("admin", name);
+    let session = test_db.validate_session("session_token").await.unwrap();
+    assert_eq!("admin", session.name);
 
     let duration = std::time::Duration::from_secs(2);
     std::thread::sleep(duration);
@@ -967,8 +967,8 @@ async fn delete_session_token_works(test_db: &kellnr_db::Database) {
         .add_session_token("admin", "session_token")
         .await
         .unwrap();
-    let (name, _) = test_db.validate_session("session_token").await.unwrap();
-    assert_eq!("admin", name);
+    let session = test_db.validate_session("session_token").await.unwrap();
+    assert_eq!("admin", session.name);
 
     test_db.delete_session_token("session_token").await.unwrap();
 
@@ -982,8 +982,8 @@ async fn delete_session_token_no_token(test_db: &kellnr_db::Database) {
         .add_session_token("admin", "session_token")
         .await
         .unwrap();
-    let (name, _) = test_db.validate_session("session_token").await.unwrap();
-    assert_eq!("admin", name);
+    let session = test_db.validate_session("session_token").await.unwrap();
+    assert_eq!("admin", session.name);
 
     let r = test_db.delete_session_token("no_token").await;
 
@@ -996,14 +996,41 @@ async fn get_name_valid_user_and_token(test_db: &kellnr_db::Database) {
         .add_session_token("admin", "session_token")
         .await
         .unwrap();
-    let (name, _) = test_db.validate_session("session_token").await.unwrap();
+    let session = test_db.validate_session("session_token").await.unwrap();
 
-    assert_eq!("admin", name);
+    assert_eq!("admin", session.name);
 }
 
 #[db_test]
 async fn get_session_no_session_in_db(test_db: &kellnr_db::Database) {
     assert!(test_db.validate_session("no_session_token").await.is_err());
+}
+
+#[db_test]
+async fn validate_session_returns_read_only_and_admin_flags(test_db: &kellnr_db::Database) {
+    // read-only, non-admin user
+    test_db
+        .add_user("rouser", "pwd", "salt", false, true)
+        .await
+        .unwrap();
+    test_db
+        .add_session_token("rouser", "ro_session")
+        .await
+        .unwrap();
+
+    let session = test_db.validate_session("ro_session").await.unwrap();
+    assert_eq!("rouser", session.name);
+    assert!(!session.is_admin);
+    assert!(session.is_read_only);
+
+    // default admin user is an admin and not read-only
+    test_db
+        .add_session_token("admin", "admin_session")
+        .await
+        .unwrap();
+    let admin = test_db.validate_session("admin_session").await.unwrap();
+    assert!(admin.is_admin);
+    assert!(!admin.is_read_only);
 }
 
 #[db_test]

--- a/crates/kellnr/src/routes/toolchain_routes.rs
+++ b/crates/kellnr/src/routes/toolchain_routes.rs
@@ -1212,7 +1212,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db.expect_list_toolchains().returning(|| Ok(vec![]));
 
         let state = create_app_state(Arc::new(mock_db), None);
@@ -1237,7 +1243,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("user_session"))
-            .returning(|_| Ok(("user".to_string(), false)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let state = create_app_state(Arc::new(mock_db), None);
         let router = create_test_router(state);
@@ -1280,7 +1292,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("user_session"))
-            .returning(|_| Ok(("user".to_string(), false)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let state = create_app_state(Arc::new(mock_db), None);
         let router = create_test_router(state);
@@ -1307,7 +1325,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("user_session"))
-            .returning(|_| Ok(("user".to_string(), false)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let state = create_app_state(Arc::new(mock_db), None);
         let router = create_test_router(state);
@@ -1331,7 +1355,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("user_session"))
-            .returning(|_| Ok(("user".to_string(), false)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let state = create_app_state(Arc::new(mock_db), None);
         let router = create_test_router(state);
@@ -1355,7 +1385,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("user_session"))
-            .returning(|_| Ok(("user".to_string(), false)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let state = create_app_state(Arc::new(mock_db), None);
         let router = create_test_router(state);
@@ -1384,7 +1420,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db.expect_list_toolchains().returning(|| {
             Ok(vec![ToolchainWithTargets {
                 id: 1,
@@ -1434,7 +1476,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db.expect_get_channels().returning(|| {
             Ok(vec![ChannelInfo {
                 name: "stable".to_string(),
@@ -1475,7 +1523,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("1.0.0"))
@@ -1522,7 +1576,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("1.0.0"))
@@ -1575,7 +1635,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("1.0.0"))
@@ -1647,7 +1713,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("1.0.0"))
@@ -1715,7 +1787,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("1.0.0"))
@@ -1787,7 +1865,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("99.99.99"))
@@ -1819,7 +1903,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("user_session"))
-            .returning(|_| Ok(("user".to_string(), false)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let state = create_app_state(Arc::new(mock_db), None);
         let router = create_test_router(state);
@@ -1845,7 +1935,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
 
         // No toolchain storage configured
         let state = create_app_state(Arc::new(mock_db), None);
@@ -1882,7 +1978,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("1.0.0"))
@@ -1936,7 +2038,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("admin_session"))
-            .returning(|_| Ok(("admin".to_string(), true)));
+            .returning(|_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_get_toolchain_by_version()
             .with(eq("rust"), eq("99.99.99"))

--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -232,6 +232,11 @@ pub async fn remove_crate_group(
     State(db): DbState,
     Path((crate_name, name)): Path<(OriginalName, String)>,
 ) -> ApiResult<Json<crate_group::CrateGroupResponse>> {
+    // Check if user is read-only and can't remove a crate group.
+    // Admin users bypass this check as they can modify
+    // their read-only status.
+    check_can_modify(&user)?;
+
     let crate_name = crate_name.to_normalized();
     check_ownership(&crate_name, &user, &db).await?;
 
@@ -449,6 +454,11 @@ pub async fn add_crate_group(
     State(db): DbState,
     Path((crate_name, name)): Path<(OriginalName, String)>,
 ) -> ApiResult<Json<crate_group::CrateGroupResponse>> {
+    // Check if user is read-only and can't add a crate group.
+    // Admin users bypass this check as they can modify
+    // their read-only status.
+    check_can_modify(&user)?;
+
     let crate_name = crate_name.to_normalized();
     check_ownership(&crate_name, &user, &db).await?;
 
@@ -1458,7 +1468,143 @@ mod reg_api_tests {
             .await
             .unwrap();
 
-        assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+        // Session now decrypts and validates: a logged-in non-owner is
+        // rejected by the ownership check (403), not treated as anonymous.
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+    }
+
+    // A read-only user who is an owner must not be able to modify a crate
+    // through the web session. Read-only state is now resolved for session
+    // auth, so `check_can_modify` rejects the request.
+    #[tokio::test]
+    async fn add_owner_single_read_only_owner_session_is_forbidden() {
+        let settings = get_settings();
+        let kellnr = TestKellnr::new(settings).await;
+
+        // publish crate as admin so `test_lib` exists
+        let valid_pub_package = read("../../tests/fixtures/test-data/pub_data.bin")
+            .await
+            .expect("Cannot open valid package file.");
+        let _ = kellnr
+            .client
+            .clone()
+            .oneshot(
+                Request::put("/api/v1/crates/new")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::AUTHORIZATION, TOKEN)
+                    .body(Body::from(valid_pub_package))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // create a read-only user and make them an owner of the crate
+        kellnr
+            .db
+            .add_user("rouser", "123", "123", false, true)
+            .await
+            .unwrap();
+        kellnr
+            .db
+            .add_owner(
+                &NormalizedName::from_unchecked("test_lib".to_string()),
+                "rouser",
+            )
+            .await
+            .unwrap();
+
+        // create a session for the read-only owner
+        kellnr.db.add_session_token("rouser", "1234").await.unwrap();
+        let cookie_header = test_cookie_helper::cookies::encode_cookies([(
+            kellnr_settings::constants::COOKIE_SESSION_ID,
+            "1234",
+        )]);
+
+        // read-only owner tries to add an owner via the browser session
+        let r = kellnr
+            .client
+            .clone()
+            .oneshot(
+                Request::put("/api/v1/crates/test_lib/owners/admin")
+                    .header(header::COOKIE, cookie_header)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // ReadOnlyModify maps to 400 Bad Request
+        assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // Counterpart to the read-only test: a normal (writable) owner must still
+    // be able to modify the crate through the web session.
+    #[tokio::test]
+    async fn add_owner_single_writable_owner_session_is_allowed() {
+        let settings = get_settings();
+        let kellnr = TestKellnr::new(settings).await;
+
+        // publish crate as admin so `test_lib` exists
+        let valid_pub_package = read("../../tests/fixtures/test-data/pub_data.bin")
+            .await
+            .expect("Cannot open valid package file.");
+        let _ = kellnr
+            .client
+            .clone()
+            .oneshot(
+                Request::put("/api/v1/crates/new")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::AUTHORIZATION, TOKEN)
+                    .body(Body::from(valid_pub_package))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // a writable owner and a target user to be added as owner
+        kellnr
+            .db
+            .add_user("rwowner", "123", "123", false, false)
+            .await
+            .unwrap();
+        kellnr
+            .db
+            .add_owner(
+                &NormalizedName::from_unchecked("test_lib".to_string()),
+                "rwowner",
+            )
+            .await
+            .unwrap();
+        kellnr
+            .db
+            .add_user("target", "123", "123", false, false)
+            .await
+            .unwrap();
+
+        // create a session for the writable owner
+        kellnr
+            .db
+            .add_session_token("rwowner", "1234")
+            .await
+            .unwrap();
+        let cookie_header = test_cookie_helper::cookies::encode_cookies([(
+            kellnr_settings::constants::COOKIE_SESSION_ID,
+            "1234",
+        )]);
+
+        let r = kellnr
+            .client
+            .clone()
+            .oneshot(
+                Request::put("/api/v1/crates/test_lib/owners/target")
+                    .header(header::COOKIE, cookie_header)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(r.status(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -1511,7 +1657,9 @@ mod reg_api_tests {
             .await
             .unwrap();
 
-        assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+        // Session now decrypts and validates: a logged-in non-owner is
+        // rejected by the ownership check (403), not treated as anonymous.
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
@@ -2481,6 +2629,9 @@ mod reg_api_tests {
             db: Arc::new(db),
             settings: settings.into(),
             crate_storage: cs.into(),
+            // Use a fixed signing key matching the test cookie helper so that
+            // session cookies actually decrypt and session auth is exercised.
+            signing_key: cookie::Key::from(test_cookie_helper::cookies::TEST_KEY),
             ..kellnr_appstate::test_state()
         };
 

--- a/crates/web-ui/src/session.rs
+++ b/crates/web-ui/src/session.rs
@@ -73,8 +73,8 @@ impl FromRequestParts<AppStateData> for AdminUser {
         let session_cookie = jar.get(COOKIE_SESSION_ID);
         match session_cookie {
             Some(cookie) => match state.db.validate_session(cookie.value()).await {
-                Ok((name, true)) => Ok(Self(name)),
-                Ok((_, false)) => Err(RouteError::InsufficientPrivileges),
+                Ok(session) if session.is_admin => Ok(Self(session.name)),
+                Ok(_) => Err(RouteError::InsufficientPrivileges),
                 Err(_) => Err(RouteError::Status(StatusCode::UNAUTHORIZED)),
             },
             None => Err(RouteError::Status(StatusCode::UNAUTHORIZED)),
@@ -142,10 +142,8 @@ impl FromRequestParts<AppStateData> for MaybeUser {
         let session_cookie = jar.get(COOKIE_SESSION_ID);
         match session_cookie {
             Some(cookie) => match state.db.validate_session(cookie.value()).await {
-                // admin
-                Ok((name, true)) => Ok(Self::Admin(name)),
-                // not admin
-                Ok((name, false)) => Ok(Self::Normal(name)),
+                Ok(session) if session.is_admin => Ok(Self::Admin(session.name)),
+                Ok(session) => Ok(Self::Normal(session.name)),
                 Err(_) => Err(RouteError::Status(StatusCode::UNAUTHORIZED)),
             },
             None => Err(RouteError::Status(StatusCode::UNAUTHORIZED)),
@@ -164,10 +162,8 @@ impl OptionalFromRequestParts<AppStateData> for MaybeUser {
         let session_cookie = jar.get(COOKIE_SESSION_ID);
         match session_cookie {
             Some(cookie) => match state.db.validate_session(cookie.value()).await {
-                // admin
-                Ok((name, true)) => Ok(Some(Self::Admin(name))),
-                // not admin
-                Ok((name, false)) => Ok(Some(Self::Normal(name))),
+                Ok(session) if session.is_admin => Ok(Some(Self::Admin(session.name))),
+                Ok(session) => Ok(Some(Self::Normal(session.name))),
                 Err(_) => Err(RouteError::Status(StatusCode::UNAUTHORIZED)),
             },
             None => Ok(None),
@@ -263,7 +259,13 @@ mod session_tests {
         mock_db
             .expect_validate_session()
             .with(eq("1234"))
-            .returning(|_st| Ok(("admin".to_string(), true)));
+            .returning(|_st| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
 
         let r = app(Arc::new(mock_db))
             .oneshot(
@@ -286,7 +288,13 @@ mod session_tests {
         mock_db
             .expect_validate_session()
             .with(eq("1234"))
-            .returning(|_st| Ok(("admin".to_string(), false)));
+            .returning(|_st| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "admin".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let r = app(Arc::new(mock_db))
             .oneshot(
@@ -340,7 +348,13 @@ mod session_tests {
         mock_db
             .expect_validate_session()
             .with(eq("1234"))
-            .returning(|_st| Ok(("normal".to_string(), false)));
+            .returning(|_st| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "normal".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let r = app(Arc::new(mock_db))
             .oneshot(
@@ -360,7 +374,13 @@ mod session_tests {
         mock_db
             .expect_validate_session()
             .with(eq("1234"))
-            .returning(|_st| Ok(("normal".to_string(), true)));
+            .returning(|_st| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "normal".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
 
         let r = app(Arc::new(mock_db))
             .oneshot(
@@ -414,7 +434,13 @@ mod session_tests {
         mock_db
             .expect_validate_session()
             .with(eq("1234"))
-            .returning(|_st| Ok(("guest".to_string(), false)));
+            .returning(|_st| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "guest".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let r = app(Arc::new(mock_db))
             .oneshot(
@@ -434,7 +460,13 @@ mod session_tests {
         mock_db
             .expect_validate_session()
             .with(eq("1234"))
-            .returning(|_st| Ok(("guest".to_string(), true)));
+            .returning(|_st| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "guest".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
 
         let r = app(Arc::new(mock_db))
             .oneshot(
@@ -553,7 +585,13 @@ mod auth_middleware_tests {
         mock_db
             .expect_validate_session()
             .with(eq("1234"))
-            .returning(|_st| Ok(("guest".to_string(), false)));
+            .returning(|_st| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "guest".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
 
         let r = app_required_auth(Arc::new(mock_db))
             .oneshot(

--- a/crates/web-ui/src/ui.rs
+++ b/crates/web-ui/src/ui.rs
@@ -675,9 +675,13 @@ mod tests {
     #[tokio::test]
     async fn settings_no_admin_returns_unauthorized() {
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .returning(|_| Ok(("admin".to_string(), true)));
+        mock_db.expect_validate_session().returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        });
 
         let (settings, storage) = test_deps();
         let r = app(
@@ -695,9 +699,13 @@ mod tests {
     #[tokio::test]
     async fn settings_returns_from_settings() {
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .returning(|_| Ok(("admin".to_string(), true)));
+        mock_db.expect_validate_session().returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        });
 
         let (settings, storage) = test_deps();
         let r = app(
@@ -747,9 +755,13 @@ mod tests {
         use kellnr_settings::{Config, ConfigSource, SettingsProv};
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .returning(|_| Ok(("admin".to_string(), true)));
+        mock_db.expect_validate_session().returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        });
 
         let (settings, storage) = test_deps();
 
@@ -915,7 +927,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("cookie"))
-            .returning(move |_| Ok(("user".to_string(), false)));
+            .returning(move |_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
         let (mut settings, storage) = test_deps();
         settings.docs.enabled = true;
         let r = app(
@@ -950,7 +968,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("cookie"))
-            .returning(move |_| Ok(("user".to_string(), false)));
+            .returning(move |_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_crate_version_exists()
             .with(eq(1), eq("1.0.0"))
@@ -989,7 +1013,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("cookie"))
-            .returning(move |_| Ok(("user".to_string(), false)));
+            .returning(move |_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_crate_version_exists()
             .with(eq(1), eq("1.0.0"))
@@ -1049,7 +1079,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("cookie"))
-            .returning(move |_| Ok(("user".to_string(), false)));
+            .returning(move |_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: false,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_crate_version_exists()
             .with(eq(1), eq("1.0.0"))
@@ -1119,7 +1155,13 @@ mod tests {
         mock_db
             .expect_validate_session()
             .with(eq("cookie"))
-            .returning(move |_| Ok(("user".to_string(), true)));
+            .returning(move |_| {
+                Ok(kellnr_db::SessionInfo {
+                    name: "user".to_string(),
+                    is_admin: true,
+                    is_read_only: false,
+                })
+            });
         mock_db
             .expect_crate_version_exists()
             .with(eq(1), eq("1.0.0"))

--- a/crates/web-ui/src/user.rs
+++ b/crates/web-ui/src/user.rs
@@ -576,10 +576,13 @@ mod tests {
         assert!(cache.get("existing_token").await.is_some());
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("test_user".to_string(), false)));
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "test_user".to_string(),
+                is_admin: false,
+                is_read_only: false,
+            })
+        });
         mock_db
             .expect_add_auth_token()
             .times(1)
@@ -631,10 +634,13 @@ mod tests {
         assert!(cache.get("token_to_keep").await.is_some());
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("test_user".to_string(), false)));
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "test_user".to_string(),
+                is_admin: false,
+                is_read_only: false,
+            })
+        });
         mock_db.expect_get_auth_tokens().times(1).returning(|_| {
             Ok(vec![AuthToken::new(
                 1,
@@ -693,10 +699,13 @@ mod tests {
         assert!(cache.get("user_token").await.is_some());
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_delete_user()
             .times(1)
@@ -748,10 +757,13 @@ mod tests {
         assert!(cache.get("user_token").await.is_some());
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_change_read_only_state()
             .times(1)
@@ -792,10 +804,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         // Note: change_read_only_state should NOT be called because self-locking is blocked
 
         let state = test_state_with_cache(mock_db, cache.clone());
@@ -833,10 +848,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_change_read_only_state()
             .times(1)
@@ -874,10 +892,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_change_read_only_state()
             .times(1)
@@ -927,10 +948,13 @@ mod tests {
         assert!(cache.get("existing_token").await.is_some());
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_add_user()
             .times(1)
@@ -978,10 +1002,13 @@ mod tests {
         assert!(cache.get("existing_token").await.is_some());
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("test_user".to_string(), false)));
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "test_user".to_string(),
+                is_admin: false,
+                is_read_only: false,
+            })
+        });
         mock_db
             .expect_add_auth_token()
             .times(1)
@@ -1034,10 +1061,13 @@ mod tests {
         assert!(cache.get("user_token").await.is_some());
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_change_admin_state()
             .times(1)
@@ -1078,10 +1108,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         // Note: change_admin_state should NOT be called because self-demotion is blocked
 
         let state = test_state_with_cache(mock_db, cache.clone());
@@ -1117,10 +1150,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("regular_user".to_string(), false))); // NOT admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "regular_user".to_string(),
+                is_admin: false,
+                is_read_only: false,
+            })
+        }); // NOT admin
 
         let state = test_state_with_cache(mock_db, cache.clone());
         let app = Router::new()
@@ -1155,10 +1191,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_change_admin_state()
             .times(1)
@@ -1196,10 +1235,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_change_admin_state()
             .times(1)
@@ -1241,10 +1283,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_change_admin_state()
             .times(1)
@@ -1282,10 +1327,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         // Note: delete_user should NOT be called because self-deletion is blocked
 
         let state = test_state_with_cache(mock_db, cache.clone());
@@ -1320,10 +1368,13 @@ mod tests {
         let cache = Arc::new(TokenCacheManager::new(true, 60, 100));
 
         let mut mock_db = MockDb::new();
-        mock_db
-            .expect_validate_session()
-            .times(1)
-            .returning(|_| Ok(("admin".to_string(), true))); // Must be admin
+        mock_db.expect_validate_session().times(1).returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        }); // Must be admin
         mock_db
             .expect_delete_user()
             .times(1)


### PR DESCRIPTION
Session auth previously hardcoded `is_read_only: false` because `validate_session` only returned `(name, is_admin)`. As a result a read-only user authenticated via the web session could modify crate ownership and ACLs through the registry API, bypassing their read-only restriction (the token path enforced it correctly).

Introduce a `SessionInfo` struct (descriptive fields instead of an ambiguous tuple) returned by `validate_session`, carrying the real `is_read_only` flag from the DB, and propagate it through `MaybeUser::from_session` and the web-ui session extractors.

Also add the missing `check_can_modify` guards on `add_crate_group` and `remove_crate_group`, which previously skipped the read-only check entirely.

Tests:
- DB: validate_session returns read-only/admin flags (sqlite + postgres)
- Registry: read-only owner blocked from add_owner via session (400), writable owner still allowed (200)
- Fix the registry test harness to use a fixed signing key so session cookies actually decrypt; the two non-owner session tests now assert 403 (validated non-owner) instead of 401 (undecryptable cookie).