### PR TITLE
feat(auth): expire sessions server-side and clean up old rows

### DIFF
--- a/crates/db/db-testcontainer/src/lib.rs
+++ b/crates/db/db-testcontainer/src/lib.rs
@@ -39,7 +39,7 @@ pub fn db_test(_attr: TokenStream, stream: TokenStream) -> TokenStream {
                 salt: "salt".to_string(),
                 admin_pwd: "123".to_string(),
                 admin_token: Some("token".to_string()),
-                session_age: std::time::Duration::from_secs(1),
+                session_age: std::time::Duration::from_secs(3600),
             };
             let con_string = kellnr_db::ConString::Sqlite(con_string);
             let test_db = kellnr_db::Database::new(&con_string, 10).await.unwrap();
@@ -59,7 +59,7 @@ pub fn db_test(_attr: TokenStream, stream: TokenStream) -> TokenStream {
             let pg_container = image::Postgres::default().start().await.expect("Failed to start postgres container");
             let port = pg_container.get_host_port_ipv4(image::Postgres::PG_PORT).await.expect("Failed to get port");
             let admin = kellnr_db::AdminUser::new("123".to_string(), Some("token".to_string()), "salt".to_string());
-            let pg_db = kellnr_db::PgConString::new("localhost", port, "kellnr", "admin", "admin", admin);
+            let pg_db = kellnr_db::PgConString::new("localhost", port, "kellnr", "admin", "admin", admin, std::time::Duration::from_secs(3600));
             let pg_db = kellnr_db::ConString::Postgres(pg_db);
             let test_db = kellnr_db::Database::new(&pg_db, 10).await.unwrap();
 

--- a/crates/db/src/con_string.rs
+++ b/crates/db/src/con_string.rs
@@ -43,6 +43,14 @@ impl ConString {
             ConString::Sqlite(s) => s.admin_token.clone(),
         }
     }
+
+    /// Maximum lifetime of a session before it is considered expired.
+    pub fn session_age(&self) -> Duration {
+        match self {
+            ConString::Postgres(p) => p.session_age,
+            ConString::Sqlite(s) => s.session_age,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -66,10 +74,19 @@ pub struct PgConString {
     user: String,
     pwd: String,
     admin: AdminUser,
+    pub session_age: Duration,
 }
 
 impl PgConString {
-    pub fn new(addr: &str, port: u16, db: &str, user: &str, pwd: &str, admin: AdminUser) -> Self {
+    pub fn new(
+        addr: &str,
+        port: u16,
+        db: &str,
+        user: &str,
+        pwd: &str,
+        admin: AdminUser,
+        session_age: Duration,
+    ) -> Self {
         Self {
             addr: addr.to_owned(),
             port,
@@ -77,6 +94,7 @@ impl PgConString {
             user: user.to_owned(),
             pwd: pwd.to_owned(),
             admin,
+            session_age,
         }
     }
 }
@@ -94,6 +112,7 @@ impl From<&Settings> for PgConString {
                 token: s.setup.admin_token.clone(),
                 salt: generate_salt(),
             },
+            session_age: Duration::from_secs(s.registry.session_age_seconds),
         }
     }
 }

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -49,13 +49,24 @@ use crate::{
 
 const DB_DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
 
+/// Convert a [`std::time::Duration`] to a [`chrono::Duration`], saturating to
+/// the maximum representable value instead of failing on overflow.
+fn to_chrono_duration(d: std::time::Duration) -> chrono::Duration {
+    chrono::Duration::from_std(d).unwrap_or(chrono::Duration::MAX)
+}
+
 pub struct Database {
     db_con: DatabaseConnection,
+    /// Maximum lifetime of a session before it is treated as expired.
+    session_age: chrono::Duration,
 }
 
 impl Database {
-    pub fn existing(db_con: DatabaseConnection) -> Self {
-        Self { db_con }
+    pub fn existing(db_con: DatabaseConnection, session_age: std::time::Duration) -> Self {
+        Self {
+            db_con,
+            session_age: to_chrono_duration(session_age),
+        }
     }
 
     pub async fn new(con: &ConString, max_con: u32) -> Result<Self, DbError> {
@@ -67,7 +78,18 @@ impl Database {
             operations::insert_admin_credentials(&db_con, con).await?;
         }
 
-        Ok(Self { db_con })
+        Ok(Self {
+            db_con,
+            session_age: to_chrono_duration(con.session_age()),
+        })
+    }
+
+    /// Timestamp (in [`DB_DATE_FORMAT`]) before which a session is expired.
+    /// Sessions with a `created` value older than this should not validate.
+    fn session_expiry_cutoff(&self) -> String {
+        (Utc::now() - self.session_age)
+            .format(DB_DATE_FORMAT)
+            .to_string()
     }
 
     /// Looks up a user by name; returns the entity model or [`DbError::UserNotFound`].
@@ -677,9 +699,12 @@ impl DbProvider for Database {
     }
 
     async fn validate_session(&self, session_token: &str) -> DbResult<SessionInfo> {
+        // An expired session is treated like a missing one: the age filter
+        // makes it invisible here so callers get the same SessionNotFound.
         let u = user::Entity::find()
             .join(JoinType::InnerJoin, user::Relation::Session.def())
             .filter(session::Column::Token.eq(session_token))
+            .filter(session::Column::Created.gte(self.session_expiry_cutoff()))
             .one(&self.db_con)
             .await?
             .ok_or(DbError::SessionNotFound)?;
@@ -689,6 +714,14 @@ impl DbProvider for Database {
             is_admin: u.is_admin,
             is_read_only: u.is_read_only,
         })
+    }
+
+    async fn delete_expired_sessions(&self) -> DbResult<u64> {
+        let res = session::Entity::delete_many()
+            .filter(session::Column::Created.lt(self.session_expiry_cutoff()))
+            .exec(&self.db_con)
+            .await?;
+        Ok(res.rows_affected)
     }
 
     async fn add_session_token(&self, name: &str, session_token: &str) -> DbResult<()> {

--- a/crates/db/src/database/test_utils.rs
+++ b/crates/db/src/database/test_utils.rs
@@ -371,6 +371,35 @@ pub async fn clean_db(db: &Database, session_age: std::time::Duration) -> DbResu
     Ok(())
 }
 
+/// Insert a session whose `created` timestamp is `age` in the past.
+///
+/// Used to test session-expiry behavior without sleeping: pass an `age`
+/// larger than the configured session age to create an already-expired
+/// session, or a small one to create a still-valid session.
+pub async fn add_aged_session(
+    db: &Database,
+    user_name: &str,
+    token: &str,
+    age: std::time::Duration,
+) -> DbResult<()> {
+    let user = user::Entity::find()
+        .filter(user::Column::Name.eq(user_name))
+        .one(&db.db_con)
+        .await?
+        .ok_or_else(|| DbError::UserNotFound(user_name.to_owned()))?;
+
+    let age = chrono::Duration::from_std(age).expect("session age out of range");
+    let created = (Utc::now() - age).format(DB_DATE_FORMAT).to_string();
+    let s = session::ActiveModel {
+        token: Set(token.to_owned()),
+        created: Set(created),
+        user_fk: Set(user.id),
+        ..Default::default()
+    };
+    s.insert(&db.db_con).await?;
+    Ok(())
+}
+
 /// Get crate meta list by crate ID.
 pub async fn get_crate_meta_list(db: &Database, crate_id: i64) -> DbResult<Vec<CrateMeta>> {
     let cm: Vec<(crate_meta::Model, Option<krate::Model>)> = crate_meta::Entity::find()

--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -143,6 +143,9 @@ pub trait DbProvider: Send + Sync {
         count: u64,
     ) -> DbResult<()>;
     async fn validate_session(&self, session_token: &str) -> DbResult<SessionInfo>;
+    /// Delete all sessions that have outlived the configured session age.
+    /// Returns the number of rows removed.
+    async fn delete_expired_sessions(&self) -> DbResult<u64>;
     async fn add_session_token(&self, name: &str, session_token: &str) -> DbResult<()>;
     async fn add_crate_user(&self, crate_name: &NormalizedName, user: &str) -> DbResult<()>;
     async fn add_owner(&self, crate_name: &NormalizedName, owner: &str) -> DbResult<()>;
@@ -459,6 +462,10 @@ pub mod mock {
             }
 
             async fn validate_session(&self, _session_token: &str) -> DbResult<SessionInfo> {
+                unimplemented!()
+            }
+
+            async fn delete_expired_sessions(&self) -> DbResult<u64> {
                 unimplemented!()
             }
 

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -1006,6 +1006,60 @@ async fn get_session_no_session_in_db(test_db: &kellnr_db::Database) {
     assert!(test_db.validate_session("no_session_token").await.is_err());
 }
 
+// Test harness configures a 3600s session age (see db-testcontainer).
+#[db_test]
+async fn validate_session_rejects_expired(test_db: &kellnr_db::Database) {
+    add_aged_session(
+        test_db,
+        "admin",
+        "fresh",
+        std::time::Duration::from_secs(60),
+    )
+    .await
+    .unwrap();
+    add_aged_session(
+        test_db,
+        "admin",
+        "stale",
+        std::time::Duration::from_secs(7200),
+    )
+    .await
+    .unwrap();
+
+    // A session within the age window validates.
+    assert!(test_db.validate_session("fresh").await.is_ok());
+    // An expired session is rejected (treated as not found), even though the
+    // row still exists in the DB.
+    assert!(test_db.validate_session("stale").await.is_err());
+}
+
+#[db_test]
+async fn delete_expired_sessions_removes_only_old(test_db: &kellnr_db::Database) {
+    add_aged_session(
+        test_db,
+        "admin",
+        "fresh",
+        std::time::Duration::from_secs(60),
+    )
+    .await
+    .unwrap();
+    add_aged_session(
+        test_db,
+        "admin",
+        "stale",
+        std::time::Duration::from_secs(7200),
+    )
+    .await
+    .unwrap();
+
+    let removed = test_db.delete_expired_sessions().await.unwrap();
+    assert_eq!(removed, 1);
+
+    // The fresh session survived; the expired one was removed.
+    assert!(test_db.validate_session("fresh").await.is_ok());
+    assert!(test_db.validate_session("stale").await.is_err());
+}
+
 #[db_test]
 async fn validate_session_returns_read_only_and_admin_flags(test_db: &kellnr_db::Database) {
     // read-only, non-admin user

--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -200,6 +200,26 @@ async fn run_server(resolved: ResolvedSettings) {
         });
     }
 
+    // Periodically remove sessions that have outlived `session_age_seconds`.
+    // validate_session already rejects expired sessions on read; this keeps the
+    // session table from growing unbounded. Run at most hourly, at least every
+    // minute, and once immediately on startup to clear sessions left by a
+    // previous run.
+    let session_cleanup_interval = settings.registry.session_age_seconds.clamp(60, 3600);
+    let session_cleanup_db = db.clone();
+    trace!("Starting session cleanup task (interval: {session_cleanup_interval}s)");
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(session_cleanup_interval));
+        loop {
+            interval.tick().await;
+            match session_cleanup_db.delete_expired_sessions().await {
+                Ok(n) if n > 0 => trace!("Removed {n} expired session(s)"),
+                Ok(_) => {}
+                Err(e) => warn!("Failed to delete expired sessions: {e}"),
+            }
+        }
+    });
+
     let download_counter_for_shutdown = download_counter.clone();
 
     let proxy_client = build_client(


### PR DESCRIPTION
Previously validate_session only checked that a session token existed; it never compared the stored `created` timestamp against the configured session age. The cookie max-age is client-enforced only, so a captured session token stayed valid in the DB indefinitely, and the session table grew without bound (clean_db existed but was a test-only helper, never wired into the running server).

validate_session now filters out sessions older than the session age, so an expired session behaves exactly like a missing one (SessionNotFound -> 401). A new delete_expired_sessions DB method plus a background task in main.rs periodically prunes expired rows (run at most hourly, at least every minute, and once on startup).

session_age is now carried on both ConString variants (it was previously Sqlite-only and unused) and stored on Database, so validate_session's signature and all its call sites are unchanged.

Tests (sqlite + postgres): a fresh session validates while an expired one is rejected though its row still exists; delete_expired_sessions removes only the expired row. Adds a test_utils::add_aged_session helper to create backdated sessions without sleeping.