### PR TITLE
fix(auth): harden session expiry edge cases

### DIFF
--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -49,26 +49,34 @@ use crate::{
 
 const DB_DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
 
-/// Convert a [`std::time::Duration`] to a [`chrono::Duration`], saturating to
-/// the maximum representable value instead of failing on overflow.
-fn to_chrono_duration(d: std::time::Duration) -> chrono::Duration {
-    chrono::Duration::from_std(d).unwrap_or(chrono::Duration::MAX)
+/// Upper bound on the configured session age. Clamping to this keeps cutoff
+/// arithmetic well within `chrono::Duration`/`DateTime` range, avoiding
+/// overflow panics for absurd configuration values.
+const MAX_SESSION_AGE: std::time::Duration =
+    std::time::Duration::from_secs(100 * 365 * 24 * 60 * 60);
+
+/// Resolve a configured session age into the internal expiry duration.
+///
+/// A value of zero means sessions never expire ([`None`]). Any positive value
+/// is clamped to [`MAX_SESSION_AGE`] so cutoff calculations cannot overflow.
+fn session_age_to_duration(d: std::time::Duration) -> Option<chrono::Duration> {
+    if d.is_zero() {
+        return None;
+    }
+    let clamped = d.min(MAX_SESSION_AGE);
+    // `clamped` is at most MAX_SESSION_AGE, which fits comfortably in a
+    // `chrono::Duration`, so the conversion cannot fail.
+    Some(chrono::Duration::from_std(clamped).expect("clamped session age fits chrono::Duration"))
 }
 
 pub struct Database {
     db_con: DatabaseConnection,
-    /// Maximum lifetime of a session before it is treated as expired.
-    session_age: chrono::Duration,
+    /// Maximum lifetime of a session before it is treated as expired, or
+    /// `None` if sessions never expire (configured age of zero).
+    session_age: Option<chrono::Duration>,
 }
 
 impl Database {
-    pub fn existing(db_con: DatabaseConnection, session_age: std::time::Duration) -> Self {
-        Self {
-            db_con,
-            session_age: to_chrono_duration(session_age),
-        }
-    }
-
     pub async fn new(con: &ConString, max_con: u32) -> Result<Self, DbError> {
         let db_con = init_database(con, max_con)
             .await
@@ -80,16 +88,16 @@ impl Database {
 
         Ok(Self {
             db_con,
-            session_age: to_chrono_duration(con.session_age()),
+            session_age: session_age_to_duration(con.session_age()),
         })
     }
 
-    /// Timestamp (in [`DB_DATE_FORMAT`]) before which a session is expired.
-    /// Sessions with a `created` value older than this should not validate.
-    fn session_expiry_cutoff(&self) -> String {
-        (Utc::now() - self.session_age)
-            .format(DB_DATE_FORMAT)
-            .to_string()
+    /// Timestamp (in [`DB_DATE_FORMAT`]) before which a session is expired, or
+    /// `None` when sessions never expire. A session whose `created` value is
+    /// older than the returned cutoff should not validate.
+    fn session_expiry_cutoff(&self) -> Option<String> {
+        self.session_age
+            .map(|age| (Utc::now() - age).format(DB_DATE_FORMAT).to_string())
     }
 
     /// Looks up a user by name; returns the entity model or [`DbError::UserNotFound`].
@@ -701,10 +709,15 @@ impl DbProvider for Database {
     async fn validate_session(&self, session_token: &str) -> DbResult<SessionInfo> {
         // An expired session is treated like a missing one: the age filter
         // makes it invisible here so callers get the same SessionNotFound.
-        let u = user::Entity::find()
+        // With expiry disabled (no cutoff) the filter is omitted.
+        let mut query = user::Entity::find()
             .join(JoinType::InnerJoin, user::Relation::Session.def())
-            .filter(session::Column::Token.eq(session_token))
-            .filter(session::Column::Created.gte(self.session_expiry_cutoff()))
+            .filter(session::Column::Token.eq(session_token));
+        if let Some(cutoff) = self.session_expiry_cutoff() {
+            query = query.filter(session::Column::Created.gte(cutoff));
+        }
+
+        let u = query
             .one(&self.db_con)
             .await?
             .ok_or(DbError::SessionNotFound)?;
@@ -717,8 +730,12 @@ impl DbProvider for Database {
     }
 
     async fn delete_expired_sessions(&self) -> DbResult<u64> {
+        // Expiry disabled: nothing to remove.
+        let Some(cutoff) = self.session_expiry_cutoff() else {
+            return Ok(0);
+        };
         let res = session::Entity::delete_many()
-            .filter(session::Column::Created.lt(self.session_expiry_cutoff()))
+            .filter(session::Column::Created.lt(cutoff))
             .exec(&self.db_con)
             .await?;
         Ok(res.rows_affected)
@@ -2268,4 +2285,33 @@ impl DbProvider for Database {
 
 fn parse_db_version(value: &str) -> DbResult<Version> {
     Version::try_from(value).map_err(|_| DbError::InvalidVersion(value.to_owned()))
+}
+
+#[cfg(test)]
+mod session_age_tests {
+    use super::{MAX_SESSION_AGE, session_age_to_duration};
+
+    #[test]
+    fn zero_means_never_expire() {
+        assert_eq!(session_age_to_duration(std::time::Duration::ZERO), None);
+    }
+
+    #[test]
+    fn positive_age_is_preserved() {
+        assert_eq!(
+            session_age_to_duration(std::time::Duration::from_secs(3600)),
+            Some(chrono::Duration::seconds(3600))
+        );
+    }
+
+    #[test]
+    fn absurd_age_is_clamped_without_panicking() {
+        // u64::MAX seconds would overflow chrono::Duration if not clamped.
+        let resolved = session_age_to_duration(std::time::Duration::from_secs(u64::MAX))
+            .expect("non-zero age yields Some");
+        assert_eq!(
+            resolved,
+            chrono::Duration::from_std(MAX_SESSION_AGE).unwrap()
+        );
+    }
 }

--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -202,23 +202,27 @@ async fn run_server(resolved: ResolvedSettings) {
 
     // Periodically remove sessions that have outlived `session_age_seconds`.
     // validate_session already rejects expired sessions on read; this keeps the
-    // session table from growing unbounded. Run at most hourly, at least every
-    // minute, and once immediately on startup to clear sessions left by a
-    // previous run.
-    let session_cleanup_interval = settings.registry.session_age_seconds.clamp(60, 3600);
-    let session_cleanup_db = db.clone();
-    trace!("Starting session cleanup task (interval: {session_cleanup_interval}s)");
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(session_cleanup_interval));
-        loop {
-            interval.tick().await;
-            match session_cleanup_db.delete_expired_sessions().await {
-                Ok(n) if n > 0 => trace!("Removed {n} expired session(s)"),
-                Ok(_) => {}
-                Err(e) => warn!("Failed to delete expired sessions: {e}"),
+    // session table from growing unbounded. A configured age of zero disables
+    // expiry, so the cleanup task is not started. Otherwise run at most hourly,
+    // at least every minute, and once immediately on startup to clear sessions
+    // left by a previous run.
+    let session_age_seconds = settings.registry.session_age_seconds;
+    if session_age_seconds > 0 {
+        let session_cleanup_interval = session_age_seconds.clamp(60, 3600);
+        let session_cleanup_db = db.clone();
+        trace!("Starting session cleanup task (interval: {session_cleanup_interval}s)");
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(session_cleanup_interval));
+            loop {
+                interval.tick().await;
+                match session_cleanup_db.delete_expired_sessions().await {
+                    Ok(n) if n > 0 => trace!("Removed {n} expired session(s)"),
+                    Ok(_) => {}
+                    Err(e) => warn!("Failed to delete expired sessions: {e}"),
+                }
             }
-        }
-    });
+        });
+    }
 
     let download_counter_for_shutdown = download_counter.clone();
 


### PR DESCRIPTION
Follow-up to the server-side session expiry feature (#1245):

- A configured session_age_seconds of 0 now disables expiry entirely: validate_session skips the age filter, delete_expired_sessions is a no-op, and the cleanup task is not started. Previously 0 made every session expire immediately, locking everyone out.
- Positive session ages are clamped to a sane maximum (100 years) so the cutoff subtraction (Utc::now() - age) cannot overflow and panic for absurd configuration values.
- Removed the unused Database::existing constructor (dead code).

Adds unit tests for the zero / positive / clamped session-age resolution.