### PR TITLE
Sparse index responses must end with a trailing newline

### DIFF
--- a/crates/common/src/index_metadata.rs
+++ b/crates/common/src/index_metadata.rs
@@ -221,12 +221,8 @@ impl IndexMetadata {
             .map(serde_json::to_string)
             .collect::<Result<Vec<_>, serde_json::Error>>()?;
         let mut index = String::new();
-        for (i, ix) in indices.iter().enumerate() {
-            if i == indices.len() - 1 {
-                write!(&mut index, "{ix}").unwrap();
-            } else {
-                writeln!(&mut index, "{ix}").unwrap();
-            }
+        for ix in &indices {
+            writeln!(&mut index, "{ix}").unwrap();
         }
         Ok(index)
     }
@@ -552,5 +548,42 @@ mod tests {
         assert_eq!(pubtime.hour(), 9);
         assert_eq!(pubtime.minute(), 5);
         assert_eq!(pubtime.second(), 7);
+    }
+
+    #[test]
+    fn serialize_indices_ends_with_newline_and_one_line_per_entry() {
+        let mk = |vers: &str| IndexMetadata {
+            name: "crate".to_string(),
+            vers: vers.to_string(),
+            deps: vec![],
+            cksum: "cksum".to_string(),
+            features: BTreeMap::default(),
+            yanked: false,
+            links: None,
+            pubtime: None,
+            v: Some(1),
+            features2: None,
+        };
+        let indices = vec![mk("1.0.0"), mk("2.0.0")];
+
+        let out = IndexMetadata::serialize_indices(&indices).unwrap();
+
+        // crates.io terminates the sparse-index body with a trailing newline,
+        // including after the final entry. Cargo tolerates a missing final
+        // newline, but `cargo install-update` / `cargo outdated` stream the body
+        // and treat an unterminated last line as "trailing garbage". Guard
+        // against regressing to `write!` (no newline) on the last line.
+        assert!(
+            out.ends_with('\n'),
+            "sparse index body must end with a newline, got: {out:?}"
+        );
+
+        // Exactly one newline-terminated JSON line per entry; no blank trailing line.
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), indices.len());
+        for (line, meta) in lines.iter().zip(&indices) {
+            let parsed: IndexMetadata = serde_json::from_str(line).unwrap();
+            assert_eq!(parsed.vers, meta.vers);
+        }
     }
 }


### PR DESCRIPTION
### Summary

Kellnr's sparse index responses do not terminate the final line with a newline (`\n`). crates.io always ends the response body with `\n`, including after the last entry. `cargo` itself tolerates the missing newline, but third-party tooling that streams and parses the index line-by-line — notably `cargo install-update` (cargo-update) and `cargo outdated` — treats the unterminated final line as trailing garbage and fails.

This affects **both** the private registry (`/api/v1/crates/`) and the crates.io pull-through proxy (`/api/v1/cratesio/`), since both serialize through the same function.

### Symptom

With Kellnr configured as a crates.io mirror via source replacement:

```toml
[source.crates-io]
replace-with = "kellnr"
[source.kellnr]
registry = "sparse+https://my-kellnr/api/v1/cratesio/"
```

- `cargo build` / `cargo update` / `cargo install` → **work fine**
- `cargo install-update -l` / `cargo outdated` → **fail**:

```
Polling registry 'https://my-kellnr/api/v1/cratesio/'.
Failed to update index repository kellnr: package cargo-update: 3052 bytes of trailing garbage.
```

### Root cause

`IndexMetadata::serialize_indices` (`crates/common/src/index_metadata.rs`) special-cased the last entry: every line except the last was written with `writeln!` (appending `\n`), and the last with `write!` (no `\n`). So the response body ended mid-line.

Why this only breaks some clients: `cargo` splits the body and parses each non-empty line, so a missing final newline is harmless. `cargo install-update`, however, streams the response through a libcurl write callback that splits on `\n` and buffers any fragment **not** terminated by `\n`, expecting more data. When the transfer ends with a
non-empty buffer (the unterminated final line), it reports `package <name>: N bytes of trailing garbage` — where `N` is exactly the byte length of that last line. crates.io never hits this because it always sends the trailing `\n`.

### Fix

Terminate every line — including the last — with a newline, matching crates.io:

```rust
let mut index = String::new();
for ix in &indices {
    writeln!(&mut index, "{ix}").unwrap();
}
Ok(index)
```

Both registry endpoints funnel through this function, so this single change fixes both. `Content-Length` and the `ETag` (sha256 of the same bytes) are derived from this body, so they remain consistent.

### How the bug was found

This was investigated with Claude Code. It:

1. Captured the raw sparse-index responses from a Kellnr instance and from crates.io for the same crate and compared them byte-for-byte. Kellnr's body ended in `..."v":1}` (no newline) while crates.io ended in `...Z"}\n`. For `serde`, Kellnr had **624 bytes after the last newline**; crates.io had **0**.
2. Read the `cargo install-update` source (`cargo-update`, `src/ops/mod.rs`, `SparseHandler`) and confirmed the "N bytes of trailing garbage" error fires exactly when the streaming buffer is non-empty at end of transfer — i.e. when the last line is not newline-terminated. The reported `N` matched the measured trailing byte count.
3. Traced Kellnr's serialization to `serialize_indices` and identified the `write!` vs `writeln!` asymmetry on the final line as the cause.

### How the patch was verified

I built a patched image from `v6.4.0` with this change and verified it myself:

- **Byte-level:** the patched instance's `/api/v1/cratesio/se/rd/serde` response is now byte-identical to crates.io's, ending in `\n`.
- **Real tooling, before:** `cargo install-update -l cargo-update` against an unpatched instance fails with `package cargo-update: 3052 bytes of trailing garbage`.
- **Real tooling, after:** the same command against the patched instance succeeds:

  ```
  Package       Installed  Latest    Needs update
  cargo-update  v8.0.0     v20.0.2   Yes
  ```
- `cargo update` continued to work in both cases (cargo's leniency was never the issue).

### Tests

A regression test (written by Claude Code) was added to the existing `index_metadata::tests` module: `serialize_indices_ends_with_newline_and_one_line_per_entry`. It asserts the serialized body ends with `\n`, contains exactly one line per entry (no blank trailing line), and that each line round-trips back to an `IndexMetadata`. It fails against the previous `write!`-on-last-line behavior. Full `kellnr-common` test suite passes (10/10).

### Notes

- Reproduced on `v6.4.0`; the affected code is identical on current `main`.
- No existing tests were affected: `crates/db` builds its expected value via `serialize_indices` on both sides of the comparison, and the prefetch tests use substring checks.