### PR TITLE
refactor: serialize_indices in a single pass

### DIFF
--- a/crates/common/src/index_metadata.rs
+++ b/crates/common/src/index_metadata.rs
@@ -216,13 +216,9 @@ impl IndexMetadata {
     }
 
     pub fn serialize_indices(indices: &[IndexMetadata]) -> Result<String, serde_json::Error> {
-        let indices = indices
-            .iter()
-            .map(serde_json::to_string)
-            .collect::<Result<Vec<_>, serde_json::Error>>()?;
         let mut index = String::new();
-        for ix in &indices {
-            writeln!(&mut index, "{ix}").unwrap();
+        for ix in indices {
+            writeln!(&mut index, "{}", serde_json::to_string(ix)?).unwrap();
         }
         Ok(index)
     }


### PR DESCRIPTION
### Summary

Follow-up cleanup to #1247. `serialize_indices` collected every entry into an intermediate `Vec<String>` (just to propagate the serde error) and then looped a second time to build the output. This serializes each entry directly into the output buffer in a single pass.

Same output, same error behavior (`?` still propagates `serde_json::Error`), one fewer allocation.

```rust
pub fn serialize_indices(indices: &[IndexMetadata]) -> Result<String, serde_json::Error> {
    let mut index = String::new();
    for ix in indices {
        writeln!(&mut index, "{}", serde_json::to_string(ix)?).unwrap();
    }
    Ok(index)
}
```

### Tests

No behavior change. Full `kellnr-common` test suite passes (10/10), including the trailing-newline regression test added in #1247.