### PR TITLE
chore: release v6.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4229,7 +4229,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4244,7 +4244,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "chrono",
@@ -4293,7 +4293,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "cargo",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "bytes",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "chrono",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "async-std",
  "chrono",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "bytes",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.5.0"
+version = "6.5.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.5.0"
+version = "6.5.1"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.5.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.5.0", path = "./crates/auth" }
-kellnr-common = { version = "6.5.0", path = "./crates/common" }
-kellnr-db = { version = "6.5.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.5.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.5.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.5.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.5.0", path = "./crates/error" }
-kellnr-index = { version = "6.5.0", path = "./crates/index" }
-kellnr-migration = { version = "6.5.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.5.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.5.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.5.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.5.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.5.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.5.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.5.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.5.1", path = "./crates/appstate" }
+kellnr-auth = { version = "6.5.1", path = "./crates/auth" }
+kellnr-common = { version = "6.5.1", path = "./crates/common" }
+kellnr-db = { version = "6.5.1", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.5.1", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.5.1", path = "./crates/docs" }
+kellnr-entity = { version = "6.5.1", path = "./crates/db/entity" }
+kellnr-error = { version = "6.5.1", path = "./crates/error" }
+kellnr-index = { version = "6.5.1", path = "./crates/index" }
+kellnr-migration = { version = "6.5.1", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.5.1", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.5.1", path = "./crates/registry" }
+kellnr-settings = { version = "6.5.1", path = "./crates/settings" }
+kellnr-storage = { version = "6.5.1", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.5.1", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.5.1", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.5.1", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.5.1

This release updates all workspace packages to version **6.5.1**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-rustfs-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [6.5.1](https://github.com/kellnr/kellnr/compare/v6.5.0...v6.5.1) - 2026-07-02

### Fixed

- *(auth)* refresh OIDC JWKS on signing-key rotation ([#1266](https://github.com/kellnr/kellnr/pull/1266))

### Other

- *(deps)* bump sea-orm-migration from 2.0.0-rc.40 to 2.0.0-rc.41 ([#1264](https://github.com/kellnr/kellnr/pull/1264))
- *(deps)* bump object_store from 0.13.2 to 0.14.0 ([#1262](https://github.com/kellnr/kellnr/pull/1262))
- *(deps)* bump quote from 1.0.45 to 1.0.46 ([#1263](https://github.com/kellnr/kellnr/pull/1263))
- *(deps)* bump time from 0.3.49 to 0.3.51 ([#1261](https://github.com/kellnr/kellnr/pull/1261))
- *(deps)* bump uuid from 1.23.3 to 1.23.4 ([#1260](https://github.com/kellnr/kellnr/pull/1260))
- *(deps)* bump sea-orm-migration from 2.0.0-rc.40 to 2.0.0-rc.41
- *(deps)* bump quote from 1.0.45 to 1.0.46
- *(deps)* bump object_store from 0.13.2 to 0.14.0
- *(deps)* bump time from 0.3.49 to 0.3.51
- *(deps)* bump uuid from 1.23.3 to 1.23.4
- serialize_indices in a single pass ([#1258](https://github.com/kellnr/kellnr/pull/1258))

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
