### PR TITLE
fix(auth): refresh OIDC JWKS on signing-key rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4249,6 +4249,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64 0.22.1",
+ "chrono",
  "hyper",
  "kellnr-appstate",
  "kellnr-common",

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -33,6 +33,7 @@ url.workspace = true
 
 
 [dev-dependencies]
+chrono.workspace = true
 hyper.workspace = true
 mockall.workspace = true
 sea-orm.workspace = true

--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -4,7 +4,7 @@
 //! code flow with PKCE.
 
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use kellnr_settings::OAuth2 as OAuth2Settings;
 use openidconnect::core::{
@@ -14,13 +14,13 @@ use openidconnect::core::{
     CoreTokenResponse,
 };
 use openidconnect::{
-    AuthorizationCode, ClientId, ClientSecret, CsrfToken, EmptyAdditionalClaims, EndpointMaybeSet,
-    EndpointNotSet, EndpointSet, IssuerUrl, Nonce, PkceCodeChallenge, PkceCodeVerifier,
-    RedirectUrl, Scope, TokenResponse, reqwest,
+    AuthorizationCode, ClaimsVerificationError, ClientId, ClientSecret, CsrfToken,
+    EmptyAdditionalClaims, EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl, Nonce,
+    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenResponse, reqwest,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{info, trace, warn};
 use url::Url;
 
 /// Type alias for the configured OIDC client after provider discovery
@@ -113,7 +113,12 @@ pub struct TokenResult {
 
 /// OAuth2/OIDC authentication handler
 pub struct OAuth2Handler {
-    client: ConfiguredCoreClient,
+    /// The configured OIDC client, wrapped so it can be rebuilt when the
+    /// provider rotates its signing keys (see [`Self::rediscover`]).
+    client: Mutex<Arc<ConfiguredCoreClient>>,
+    client_id: ClientId,
+    client_secret: Option<ClientSecret>,
+    redirect_url: RedirectUrl,
     settings: Arc<OAuth2Settings>,
     issuer_url: IssuerUrl,
     http_client: reqwest::Client,
@@ -153,12 +158,6 @@ impl OAuth2Handler {
             .build()
             .map_err(|e| OAuth2Error::HttpError(e.to_string()))?;
 
-        // Perform OIDC discovery
-        let provider_metadata =
-            CoreProviderMetadata::discover_async(issuer_url.clone(), &http_client)
-                .await
-                .map_err(|e| OAuth2Error::DiscoveryError(e.to_string()))?;
-
         let client_id = ClientId::new(
             settings
                 .client_id
@@ -170,17 +169,70 @@ impl OAuth2Handler {
 
         let redirect_url = RedirectUrl::new(redirect_url.to_string())?;
 
-        // Build the client from provider metadata
-        let client =
-            CoreClient::from_provider_metadata(provider_metadata, client_id, client_secret)
-                .set_redirect_uri(redirect_url);
+        // Perform OIDC discovery and build the client from provider metadata
+        let client = Self::discover_client(
+            &issuer_url,
+            &client_id,
+            client_secret.as_ref(),
+            &redirect_url,
+            &http_client,
+        )
+        .await?;
 
         Ok(Self {
-            client,
+            client: Mutex::new(Arc::new(client)),
+            client_id,
+            client_secret,
+            redirect_url,
             settings: Arc::new(settings.clone()),
             issuer_url,
             http_client,
         })
+    }
+
+    /// Perform OIDC discovery and build a configured client from the fetched
+    /// provider metadata (which includes the current JWKS signing keys).
+    async fn discover_client(
+        issuer_url: &IssuerUrl,
+        client_id: &ClientId,
+        client_secret: Option<&ClientSecret>,
+        redirect_url: &RedirectUrl,
+        http_client: &reqwest::Client,
+    ) -> Result<ConfiguredCoreClient, OAuth2Error> {
+        let provider_metadata =
+            CoreProviderMetadata::discover_async(issuer_url.clone(), http_client)
+                .await
+                .map_err(|e| OAuth2Error::DiscoveryError(e.to_string()))?;
+
+        Ok(CoreClient::from_provider_metadata(
+            provider_metadata,
+            client_id.clone(),
+            client_secret.cloned(),
+        )
+        .set_redirect_uri(redirect_url.clone()))
+    }
+
+    fn current_client(&self) -> Arc<ConfiguredCoreClient> {
+        self.client
+            .lock()
+            .expect("OAuth2 client mutex poisoned")
+            .clone()
+    }
+
+    /// Re-run OIDC discovery to obtain a client with a fresh JWKS.
+    ///
+    /// Used to recover from provider signing-key rotation, after which the
+    /// keys cached at startup can no longer verify newly issued tokens.
+    async fn rediscover(&self) -> Result<Arc<ConfiguredCoreClient>, OAuth2Error> {
+        Self::discover_client(
+            &self.issuer_url,
+            &self.client_id,
+            self.client_secret.as_ref(),
+            &self.redirect_url,
+            &self.http_client,
+        )
+        .await
+        .map(Arc::new)
     }
 
     /// Generate an authorization URL for the `OAuth2` flow
@@ -191,9 +243,10 @@ impl OAuth2Handler {
     pub fn generate_auth_url(&self) -> AuthRequest {
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
+        let client = self.current_client();
+
         // Build the authorization request with configured scopes
-        let mut auth_request = self
-            .client
+        let mut auth_request = client
             .authorize_url(
                 CoreAuthenticationFlow::AuthorizationCode,
                 CsrfToken::new_random,
@@ -232,15 +285,16 @@ impl OAuth2Handler {
         nonce: &str,
     ) -> Result<TokenResult, OAuth2Error> {
         let code = AuthorizationCode::new(code.to_string());
-        let verifier = PkceCodeVerifier::new(pkce_verifier.to_string());
+        let pkce_verifier = PkceCodeVerifier::new(pkce_verifier.to_string());
 
-        let token_request = self
-            .client
+        let client = self.current_client();
+
+        let token_request = client
             .exchange_code(code)
             .map_err(|e| OAuth2Error::TokenExchangeError(e.to_string()))?;
 
         let token_response: CoreTokenResponse = token_request
-            .set_pkce_verifier(verifier)
+            .set_pkce_verifier(pkce_verifier)
             .request_async(&self.http_client)
             .await
             .map_err(|e| OAuth2Error::TokenExchangeError(e.to_string()))?;
@@ -251,12 +305,28 @@ impl OAuth2Handler {
             .ok_or_else(|| OAuth2Error::MissingClaim("id_token".to_string()))?;
 
         let nonce = Nonce::new(nonce.to_string());
-        let verifier = self.client.id_token_verifier();
 
-        let claims = id_token
-            .claims(&verifier, &nonce)
-            .map_err(|e| OAuth2Error::TokenVerificationError(e.to_string()))?
-            .clone();
+        let claims = match id_token.claims(&client.id_token_verifier(), &nonce) {
+            Ok(claims) => claims.clone(),
+            // A signature failure typically means the provider rotated its
+            // signing keys since discovery, so the JWKS cached at startup is
+            // stale. Re-fetch it once and retry before giving up.
+            Err(ClaimsVerificationError::SignatureVerification(_)) => {
+                trace!(
+                    "ID token signature verification failed; refreshing OIDC JWKS and retrying (provider may have rotated signing keys)"
+                );
+                let refreshed = self.rediscover().await?;
+                let claims = id_token
+                    .claims(&refreshed.id_token_verifier(), &nonce)
+                    .map_err(|e| OAuth2Error::TokenVerificationError(e.to_string()))?
+                    .clone();
+                // Persist the refreshed client so subsequent logins reuse the
+                // new keys instead of re-fetching on every request.
+                *self.client.lock().expect("OAuth2 client mutex poisoned") = refreshed;
+                claims
+            }
+            Err(e) => return Err(OAuth2Error::TokenVerificationError(e.to_string())),
+        };
 
         // Also extract raw payload for additional claims
         let raw_payload = extract_jwt_payload(id_token.to_string().as_str())
@@ -697,5 +767,254 @@ mod tests {
         );
         assert_eq!(get_string_array_from_json(&payload, "number"), None);
         assert_eq!(get_string_array_from_json(&payload, "missing"), None);
+    }
+}
+
+/// End-to-end tests for recovering from OIDC provider signing-key rotation.
+///
+/// These spin up a minimal in-process OIDC provider (discovery, JWKS and token
+/// endpoints) whose active signing key can be swapped at runtime, mirroring a
+/// provider like Dex rotating its keys.
+#[cfg(test)]
+mod rotation_tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use axum::extract::State;
+    use axum::routing::{get, post};
+    use axum::{Json, Router};
+    use chrono::{Duration, Utc};
+    use openidconnect::core::{
+        CoreIdToken, CoreJsonWebKeySet, CoreJwsSigningAlgorithm, CoreRsaPrivateSigningKey,
+    };
+    use openidconnect::{
+        Audience, EmptyAdditionalClaims, EndUserEmail, JsonWebKeyId, PrivateSigningKey,
+        StandardClaims, SubjectIdentifier,
+    };
+    use serde_json::{Value, json};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    // Two distinct 2048-bit RSA keys (PKCS#1 PEM) used to simulate key rotation.
+    const KEY_A_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAtZ/uvzCiQirPAQf0w4piStS+zUlL6A3/ZTpTOJCpnRHVtnfh
+EPbqtQ+ohvkB8txKg2nlgDZ5+zS62jtvb2BYzwkH5qU4jlpDEOnwKVtTTjOrCWZx
+a8DVihgvcVkrYREOMRPzlXbF2aACwQAaveM8sbfu0cZ49SmQ34RQNqA8Gs+v/Nmr
+jYwwZ9rQ4XIBYE689TiBjtZJVvQa7I8Waj8euYxWP5rB1tpZVtgz2AARTn5iSgNX
+KM40IaMWLcvVUajPgYdcHE75+GLCzQAeEY4tboYo8ehFuMuehizj5sHz8ghz6reU
+D83gE5wlLndJj/c/9apvvyBYmvWyar5HIPcvEQIDAQABAoIBAAEXqMi+82H6h4JM
+duFvLowyMMlgFQr7vldpSPuSYxBEhN2YoBtJOr34T5VXrK0rPAELDzNduEmepRoK
+KHpiqSd1EJsAPVGLeWkxecPD29eoKFRjcdLT/l30ZdQVJZOa5lP+0ByGpUmhTw1y
+J98/24TXcbRjGtUsQ+4F1rnYIRVVY+RsrtWs2IaLHR8RnI6M3rFjY7y5dKX9x3Wn
+ERC1Nx7blrUMvzK1052qUTC6sCYku2nJXUKBylj095GVZpK9oje62J5c9+SSvuOQ
+MFEX0JSXfpCvoReP+9Ywa+vf+jpywja7hAIbH+bAqEnWNdrsuicTbUaRM39D1MB1
+XbKoemkCgYEA4wSokLEgQggsQ+HEjr5cTXE/dDjokp3CuuXAJg0mAhLWZro3PZnL
+dOElavpRwP4ISt3Lj47CJWcQAPGzl+BuGKPyQkRPhFkpBsUCdxgBi1eA4Suq7xa+
+ARhMEN9Ayfszh2xLD/dRgOh/cVi/x7N3IfihJ9Jd9L3p4TTCjngUC5UCgYEAzM+9
+DtPCdsNfiWtqtK/YolHUMZo3mb8Vu0e3fecIgUH3neOm/XhtxJY2wHehemyFJkYE
+f93Vp50GXEmmmPVnjXuYmrIk3jEjk3j4hn7/gi37EzNzgbSf1RN09swU31FJ5N+R
+/XZDH5zA+ZRIKU+CW8ap4cDTa1hBJNjVLqW2Fo0CgYEA1AFetjlkCaZ+SCqIGFI3
++u5+trgKohmIaGf1CNQQobEb3rWarwF4Wr+D5SK9xIC4F8qHtpo4Pxu/e1I9SOGD
+j6lTrYUDyXJGeRb01Wlqz8k5B49zQ3K2oGkjaEJFzBq2pYqBkviBeeQmWCDsgL/d
+yrDZN0ojClNtHi7aXphPB/0CgYEAr5nVYOcSrjzopqvgezbhqJo8MqMk1L9O5Jmi
+q2HwmtJyeX78aApfItQf8XkgjBSLPLt/lBog22r4TxweqLqPpHC58LiYf6Dl/cUU
+YEx2yaiewmG0wRqah1f9SrTDmIzbrE47n3NMLch6dAI8tJ6lCAcXFKX9HuY2RF9c
+uHf/3OkCgYA2KePOq4vGOGD+zKDFrI7PSJcEa62oczZidgOylc/Lr9qx2Oiz4HM9
+Di85C5B3y/3ZnYf8+1nTPdvfqTPt4aMjJKBVVWvkEA5yPYmY5FY+Z3sAA4AzGZ8Z
+Xx2ZJaH0xsmAtrhSK8StLDiXayT8ygyZnqXfbZS0nG2HX3tKksYi0Q==
+-----END RSA PRIVATE KEY-----";
+
+    const KEY_B_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEArOXZ5D7VxWmRkijS8CXQznmFL5bf3XDJ/Vll1imhJjU/sOJP
+aob5U40xIV+b0LbNhxP8C3lu+TKF3xldvv7lYTjXYfVZ3fwjfBMe6Vm5PYr31FiR
+KQLNrTrBE2cTCDoCn51NMERw/fdt0zJmfDcA77o1T6us2jxnDlrddiWYyBs26Y8p
+dYFacxObDsJwqmE60ijP92SR37NjMdwUNDg1Bzh6xw3puAP4KeFwWNNVPHwQpJEd
+pKX3T+CL2Ybfboyh9XCo2FmawfWjoIgUVoecgdpDMgNqtPjQ2HUvsH5JsWCezduE
+MW7sPloZr9doGnYVycuBCKOldwriCFJqjw2VlwIDAQABAoIBAD9lhohFLABXbcuw
+kWwCCbbz4wyon0xko4P0qD0nhZHre3+h8+nFNR3YSzgIBSu6I9GQV95jN/hC+Mht
+1iyG7VfBTmR6YOnfHqnLnw2EW0KANtBTa2KkxwLqZMp3BIkDMFwTgy6cIexVshz7
+QY3xYzQDzLF6awaYmFcwpTzBm2xfxmsjDODnMeeq4YraC/qrLn6yxFC3jH4H5fCu
+mlzYrGHAEN7mdIOQEktJXwyEzi0rVKHDfJEhStGS7gMILw7BZfFSQxnzXyHJEOt7
+3ZJY40N23H2iKaqN3s1Af56PbOcd9xmv3KM0lcmrmp2/cpoZTGSQgHNLZXB8bQ76
+L+u/WyECgYEA8hfrlpn1O66Jh7JKNl8iLFoiBGBozsyZrx0KP0yyFJ4apk7U6GzE
+7dnZJQ6sXklyE1gHSjArtICDnF8I26Jovl7EfijbQr+E4zuQhcZG3vuBzF0/8hy/
+D//QLKXvokqevEvYnt7V81Io17K80R11U5Elxhl1YwxKOMd468MUr3cCgYEAttRh
+6baK/NgktXkDhOf5Mmcz1MtUO+gop8lpOQifcPslE//6M1DE3G+6oRSZuTApSP5o
+NjwhHbu0ko/zbWWvJ760bdcv98R6z60AHFq3TZrG5R4f68o4aD+Llu1mLt26QppP
+vnby8CcCbcvCBXM4xzrORp7LOFs7fx8IsJL/EuECgYAepEZuVmhCuJGxujBId3wU
+zwe1NBqv6hedoXhVkLiNgYFwAVRTYsj+Le+dECFjAbrNlfu+OSCfBREjbqfpXMIT
+Ll2CdltiNGl2dWiSdgksWfsQydC5LUhFlyRbMlmFWhqDTLpLSXsdBA4lVvstIKRk
+AmAclcZU1g5i52R3usZYewKBgGPCn2qXYF920RD0ZycuLJuEFJQYHm5Rz10+WVv1
+iIptf13aXvuBJunhTUR3qSmTTfO2Xca6KJfAxFb0lS8sPNbDCFCnClV3sEuBan4O
+QdbmjYCXX3OZdA3uHozMHOWVtvyAluKmpQjFQF4IwGWY6XJMdCG0o86seVpz5Jn0
+m5oBAoGBAL/uJIrh8ZiL1eQrhJTitkW7BgV6iTN518Pf/I9DzOMnq/kG3W7zhQ2m
+lJZsY5m/jNCs0KrTBBEoVQzkPVlzoQ/dDYZyA2cj4LydXyuM76yth8F+DMr3ckN6
+Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
+-----END RSA PRIVATE KEY-----";
+
+    const CLIENT_ID: &str = "test-client";
+    const SUBJECT: &str = "user-subject-123";
+    const NONCE: &str = "test-nonce";
+
+    /// State shared with the mock provider's request handlers.
+    struct MockProvider {
+        issuer: String,
+        key_a: CoreRsaPrivateSigningKey,
+        key_b: CoreRsaPrivateSigningKey,
+        /// When `true`, the provider signs tokens with (and advertises) `key_b`.
+        rotated: AtomicBool,
+        /// Number of times the JWKS endpoint was fetched, i.e. how often the
+        /// handler ran discovery.
+        jwks_fetches: AtomicUsize,
+    }
+
+    impl MockProvider {
+        fn active_key(&self) -> &CoreRsaPrivateSigningKey {
+            if self.rotated.load(Ordering::SeqCst) {
+                &self.key_b
+            } else {
+                &self.key_a
+            }
+        }
+
+        /// Mint an ID token signed with the currently active key.
+        fn sign_id_token(&self) -> String {
+            let claims = CoreIdTokenClaims::new(
+                IssuerUrl::new(self.issuer.clone()).unwrap(),
+                vec![Audience::new(CLIENT_ID.to_string())],
+                Utc::now() + Duration::minutes(5),
+                Utc::now(),
+                StandardClaims::new(SubjectIdentifier::new(SUBJECT.to_string()))
+                    .set_email(Some(EndUserEmail::new("user@example.com".to_string()))),
+                EmptyAdditionalClaims {},
+            )
+            .set_nonce(Some(Nonce::new(NONCE.to_string())));
+
+            let id_token = CoreIdToken::new(
+                claims,
+                self.active_key(),
+                CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256,
+                None,
+                None,
+            )
+            .expect("signing ID token");
+
+            serde_json::to_value(&id_token)
+                .expect("serialize ID token")
+                .as_str()
+                .expect("ID token is a JWT string")
+                .to_string()
+        }
+    }
+
+    async fn discovery(State(state): State<Arc<MockProvider>>) -> Json<Value> {
+        Json(json!({
+            "issuer": state.issuer,
+            "authorization_endpoint": format!("{}/authorize", state.issuer),
+            "token_endpoint": format!("{}/token", state.issuer),
+            "jwks_uri": format!("{}/jwks", state.issuer),
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }))
+    }
+
+    async fn jwks(State(state): State<Arc<MockProvider>>) -> Json<Value> {
+        state.jwks_fetches.fetch_add(1, Ordering::SeqCst);
+        let jwks = CoreJsonWebKeySet::new(vec![state.active_key().as_verification_key()]);
+        Json(serde_json::to_value(&jwks).expect("serialize JWKS"))
+    }
+
+    async fn token(State(state): State<Arc<MockProvider>>) -> Json<Value> {
+        Json(json!({
+            "access_token": "access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "id_token": state.sign_id_token(),
+        }))
+    }
+
+    fn test_settings(issuer: &str) -> OAuth2Settings {
+        OAuth2Settings {
+            enabled: true,
+            issuer_url: Some(issuer.to_string()),
+            client_id: Some(CLIENT_ID.to_string()),
+            client_secret: Some("test-secret".to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// A signing-key rotation makes the JWKS cached at discovery stale; the
+    /// handler must re-fetch it and still verify the freshly signed token.
+    #[tokio::test]
+    async fn exchange_recovers_from_signing_key_rotation() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let issuer = format!("http://{}", listener.local_addr().unwrap());
+
+        let provider = Arc::new(MockProvider {
+            issuer: issuer.clone(),
+            key_a: CoreRsaPrivateSigningKey::from_pem(
+                KEY_A_PEM,
+                Some(JsonWebKeyId::new("key-a".to_string())),
+            )
+            .unwrap(),
+            key_b: CoreRsaPrivateSigningKey::from_pem(
+                KEY_B_PEM,
+                Some(JsonWebKeyId::new("key-b".to_string())),
+            )
+            .unwrap(),
+            rotated: AtomicBool::new(false),
+            jwks_fetches: AtomicUsize::new(0),
+        });
+
+        let app = Router::new()
+            .route("/.well-known/openid-configuration", get(discovery))
+            .route("/jwks", get(jwks))
+            .route("/token", post(token))
+            .with_state(provider.clone());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        });
+
+        // Discovery caches key A (first JWKS fetch).
+        let handler = OAuth2Handler::from_discovery(&test_settings(&issuer), "http://localhost/cb")
+            .await
+            .expect("discovery should succeed");
+        assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 1);
+
+        // Baseline: a token signed with key A verifies against the cached JWKS
+        // without triggering another discovery.
+        let result = handler
+            .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+            .await
+            .expect("baseline exchange should verify");
+        assert_eq!(result.claims.subject().as_str(), SUBJECT);
+        assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 1);
+
+        // The provider rotates keys: tokens are now signed with key B and the
+        // JWKS endpoint serves only key B. The key A cached at startup is stale.
+        provider.rotated.store(true, Ordering::SeqCst);
+
+        // Before the fix this failed with "Signature verification failed"; now
+        // the handler re-discovers the JWKS (second fetch) and verifies.
+        let result = handler
+            .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+            .await
+            .expect("exchange should succeed after JWKS refresh");
+        assert_eq!(result.claims.subject().as_str(), SUBJECT);
+        assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 2);
+
+        // The refreshed client is cached, so a subsequent login reuses key B
+        // instead of re-fetching the JWKS again.
+        let result = handler
+            .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+            .await
+            .expect("exchange should reuse the refreshed JWKS");
+        assert_eq!(result.claims.subject().as_str(), SUBJECT);
+        assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 2);
+
+        server.abort();
     }
 }


### PR DESCRIPTION
## Problem

Fixes #1265. OAuth2/OIDC login fails after the provider rotates its signing keys with:

> Failed to exchange OAuth2 code: Failed to verify ID token: Signature verification failed

## Root cause

`OAuth2Handler::from_discovery` runs OIDC discovery **once at startup**. `openidconnect`'s `discover_async` eagerly fetches the JWKS and bakes it into the client, which is then stored in `AppStateData` and reused for the entire process lifetime. When the IdP (e.g. Dex, which rotates keys every 6h by default) rotates its signing keys, the cached keys can no longer verify newly issued tokens, so `id_token.claims()` returns `ClaimsVerificationError::SignatureVerification` and **every** login stays broken until the process is restarted.

## Fix

- Make the OIDC client hot-swappable (`Mutex<Arc<ConfiguredCoreClient>>`) and store the pieces needed to rebuild it.
- On a signature-verification failure — and only that error variant — re-run discovery to fetch a fresh JWKS, retry verification once, and cache the refreshed client so subsequent logins reuse the new keys without another network round-trip.
- Expiry / nonce / audience errors are returned as-is (no refresh, no per-login latency). The authorization code is not re-exchanged; the already-obtained ID token is simply re-verified.

## Test

Added an end-to-end test with an in-process mock OIDC provider (discovery, JWKS, and token endpoints) whose active signing key can be rotated at runtime. It asserts:

- baseline login succeeds and does **not** trigger a second discovery,
- after key rotation the login recovers (re-fetches the JWKS exactly once),
- a subsequent login reuses the cached refreshed client (no further JWKS fetch).

Verified the test fails against the pre-fix code (`No matching key found`) and passes with the fix.

## Verification

- `cargo fmt -p kellnr-auth --check` — clean
- `cargo clippy -p kellnr-auth --all-targets` — no warnings
- `cargo test -p kellnr-auth` — 31 passed
- Full workspace `cargo build` — clean

No CI changes needed: the new test is a pure in-process unit test (localhost TCP only, no Docker), running under the existing `test-kellnr` job.