### PR TITLE
chore: release v6.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "chrono",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "cargo",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "bytes",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "chrono",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "async-std",
  "chrono",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "bytes",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.5.1"
+version = "6.5.2"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.5.1", path = "./crates/appstate" }
-kellnr-auth = { version = "6.5.1", path = "./crates/auth" }
-kellnr-common = { version = "6.5.1", path = "./crates/common" }
-kellnr-db = { version = "6.5.1", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.5.1", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.5.1", path = "./crates/docs" }
-kellnr-entity = { version = "6.5.1", path = "./crates/db/entity" }
-kellnr-error = { version = "6.5.1", path = "./crates/error" }
-kellnr-index = { version = "6.5.1", path = "./crates/index" }
-kellnr-migration = { version = "6.5.1", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.5.1", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.5.1", path = "./crates/registry" }
-kellnr-settings = { version = "6.5.1", path = "./crates/settings" }
-kellnr-storage = { version = "6.5.1", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.5.1", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.5.1", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.5.1", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.5.2", path = "./crates/appstate" }
+kellnr-auth = { version = "6.5.2", path = "./crates/auth" }
+kellnr-common = { version = "6.5.2", path = "./crates/common" }
+kellnr-db = { version = "6.5.2", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.5.2", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.5.2", path = "./crates/docs" }
+kellnr-entity = { version = "6.5.2", path = "./crates/db/entity" }
+kellnr-error = { version = "6.5.2", path = "./crates/error" }
+kellnr-index = { version = "6.5.2", path = "./crates/index" }
+kellnr-migration = { version = "6.5.2", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.5.2", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.5.2", path = "./crates/registry" }
+kellnr-settings = { version = "6.5.2", path = "./crates/settings" }
+kellnr-storage = { version = "6.5.2", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.5.2", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.5.2", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.5.2", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.5.2

This release updates all workspace packages to version **6.5.2**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-rustfs-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [6.5.2](https://github.com/kellnr/kellnr/compare/v6.5.1...v6.5.2) - 2026-07-22

### Other

- add signed + notarized macOS release binary
- free disk space before heavy build jobs
- *(deps-dev)* bump brace-expansion from 5.0.4 to 5.0.7 in /ui ([#1300](https://github.com/kellnr/kellnr/pull/1300))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps-dev)* bump brace-expansion from 5.0.4 to 5.0.7 in /ui
- *(deps)* bump regex from 1.13.0 to 1.13.1 ([#1293](https://github.com/kellnr/kellnr/pull/1293))
- *(deps)* bump sea-orm-migration from 2.0.0-rc.42 to 2.0.0-rc.43 ([#1298](https://github.com/kellnr/kellnr/pull/1298))
- *(deps)* bump sea-orm-migration from 2.0.0-rc.42 to 2.0.0-rc.43
- *(deps)* bump object_store from 0.14.0 to 0.14.1 ([#1297](https://github.com/kellnr/kellnr/pull/1297))
- *(deps)* bump the npm-all group in /ui with 2 updates ([#1294](https://github.com/kellnr/kellnr/pull/1294))
- *(deps)* bump object_store from 0.14.0 to 0.14.1
- *(deps)* bump uuid from 1.23.5 to 1.24.0 ([#1296](https://github.com/kellnr/kellnr/pull/1296))
- *(deps)* bump tokio from 1.52.3 to 1.53.0 ([#1295](https://github.com/kellnr/kellnr/pull/1295))
- *(deps)* bump uuid from 1.23.5 to 1.24.0
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump tokio from 1.52.3 to 1.53.0
- *(deps)* bump the npm-all group in /ui with 2 updates
- *(deps)* bump regex from 1.13.0 to 1.13.1
- *(deps)* bump serde_with from 3.16.1 to 3.21.0 ([#1292](https://github.com/kellnr/kellnr/pull/1292))
- *(deps)* bump serde_with from 3.16.1 to 3.21.0
- *(deps)* bump the npm-all group across 1 directory with 11 updates ([#1289](https://github.com/kellnr/kellnr/pull/1289))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- Merge branch 'main' into dependabot/npm_and_yarn/ui/main/npm-all-2c368b9d7a
- *(deps)* bump toml from 1.1.2+spec-1.1.0 to 1.1.3+spec-1.1.0 ([#1287](https://github.com/kellnr/kellnr/pull/1287))
- *(deps)* bump sea-orm from 2.0.0-rc.42 to 2.0.0-rc.43 ([#1290](https://github.com/kellnr/kellnr/pull/1290))
- Merge branch 'main' into dependabot/cargo/main/toml-1.1.3spec-1.1.0
- *(deps)* bump http-body-util from 0.1.3 to 0.1.4 ([#1291](https://github.com/kellnr/kellnr/pull/1291))
- Merge branch 'main' into dependabot/cargo/main/toml-1.1.3spec-1.1.0
- Merge branch 'main' into dependabot/cargo/main/sea-orm-2.0.0-rc.43
- Merge branch 'main' into dependabot/cargo/main/http-body-util-0.1.4
- fix formatting
- Merge branch 'main' into dependabot/cargo/main/toml-1.1.3spec-1.1.0
- Merge branch 'main' into dependabot/cargo/main/sea-orm-2.0.0-rc.43
- Merge branch 'main' into dependabot/cargo/main/http-body-util-0.1.4
- update flake.nix
- Merge branch 'main' into dependabot/cargo/main/sea-orm-2.0.0-rc.43
- Merge branch 'main' into dependabot/cargo/main/http-body-util-0.1.4
- Merge branch 'main' into dependabot/cargo/main/toml-1.1.3spec-1.1.0
- Merge branch 'main' of github.com:kellnr/kellnr
- fix clippy lints
- *(deps)* bump uuid from 1.23.4 to 1.23.5 ([#1288](https://github.com/kellnr/kellnr/pull/1288))
- *(deps)* bump toml from 1.1.2+spec-1.1.0 to 1.1.3+spec-1.1.0
- *(deps)* bump sea-orm from 2.0.0-rc.42 to 2.0.0-rc.43
- *(deps)* bump sea-orm-migration from 2.0.0-rc.41 to 2.0.0-rc.43 ([#1286](https://github.com/kellnr/kellnr/pull/1286))
- *(deps)* bump actions/setup-node from 6 to 7 ([#1285](https://github.com/kellnr/kellnr/pull/1285))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump http-body-util from 0.1.3 to 0.1.4
- *(deps)* bump the npm-all group across 1 directory with 11 updates
- *(deps)* bump uuid from 1.23.4 to 1.23.5
- *(deps)* bump sea-orm-migration from 2.0.0-rc.41 to 2.0.0-rc.43
- *(deps)* bump actions/setup-node from 6 to 7
- *(dependabot)* ignore TypeScript major bumps (stay on TS 6.x) ([#1284](https://github.com/kellnr/kellnr/pull/1284))
- *(ui)* add UI data test-IDs to simplify identification of elements in playwright tests
- *(deps)* bump cargo from 0.97.2 to 0.98.0 ([#1276](https://github.com/kellnr/kellnr/pull/1276))
- Merge branch 'main' into dependabot/cargo/main/cargo-0.98.0
- bump rust-overlay
- *(deps)* bump cargo from 0.97.2 to 0.98.0
- *(deps)* bump sea-orm from 2.0.0-rc.41 to 2.0.0-rc.42 ([#1279](https://github.com/kellnr/kellnr/pull/1279))
- *(deps)* bump bytes from 1.12.0 to 1.12.1 ([#1280](https://github.com/kellnr/kellnr/pull/1280))
- *(deps)* bump regex from 1.12.4 to 1.13.0 ([#1277](https://github.com/kellnr/kellnr/pull/1277))
- *(deps)* bump bytes from 1.12.0 to 1.12.1
- *(deps)* bump sea-orm from 2.0.0-rc.41 to 2.0.0-rc.42
- *(deps)* bump regex from 1.12.4 to 1.13.0
- *(deps)* bump rand from 0.10.1 to 0.10.2 ([#1272](https://github.com/kellnr/kellnr/pull/1272))
- *(deps)* bump cmov from 0.5.3 to 0.5.4 ([#1274](https://github.com/kellnr/kellnr/pull/1274))
- *(deps)* bump the npm-all group in /ui with 9 updates ([#1271](https://github.com/kellnr/kellnr/pull/1271))
- *(deps)* bump rand from 0.10.1 to 0.10.2
- *(deps)* bump cmov from 0.5.3 to 0.5.4
- *(deps)* bump cargo from 0.97.1 to 0.97.2 ([#1273](https://github.com/kellnr/kellnr/pull/1273))
- *(deps)* bump mockall from 0.14.0 to 0.15.0 ([#1270](https://github.com/kellnr/kellnr/pull/1270))
- *(deps)* bump time from 0.3.51 to 0.3.53 ([#1269](https://github.com/kellnr/kellnr/pull/1269))
- *(deps)* bump cargo from 0.97.1 to 0.97.2
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump the npm-all group in /ui with 9 updates
- *(deps)* bump mockall from 0.14.0 to 0.15.0
- *(deps)* bump time from 0.3.51 to 0.3.53

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
