### PR TITLE
feat(auth): enforce SSO-only login with RP-initiated logout

### DIFF
--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -10,13 +10,13 @@ use kellnr_settings::OAuth2 as OAuth2Settings;
 use openidconnect::core::{
     CoreAuthDisplay, CoreAuthPrompt, CoreAuthenticationFlow, CoreClient, CoreErrorResponseType,
     CoreGenderClaim, CoreIdTokenClaims, CoreJsonWebKey, CoreJweContentEncryptionAlgorithm,
-    CoreProviderMetadata, CoreRevocationErrorResponse, CoreTokenIntrospectionResponse,
-    CoreTokenResponse,
+    CoreRevocationErrorResponse, CoreTokenIntrospectionResponse, CoreTokenResponse,
 };
 use openidconnect::{
     AuthorizationCode, ClaimsVerificationError, ClientId, ClientSecret, CsrfToken,
     EmptyAdditionalClaims, EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl, Nonce,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenResponse, reqwest,
+    PkceCodeChallenge, PkceCodeVerifier, ProviderMetadataWithLogout, RedirectUrl, Scope,
+    TokenResponse, reqwest,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -109,6 +109,8 @@ pub struct TokenResult {
     pub claims: CoreIdTokenClaims,
     /// Raw JWT payload for extracting additional claims
     pub raw_payload: serde_json::Value,
+    /// Raw ID token JWT, used as `id_token_hint` for RP-initiated logout
+    pub id_token: String,
 }
 
 /// OAuth2/OIDC authentication handler
@@ -122,6 +124,7 @@ pub struct OAuth2Handler {
     settings: Arc<OAuth2Settings>,
     issuer_url: IssuerUrl,
     http_client: reqwest::Client,
+    end_session_endpoint: Option<String>,
 }
 
 impl OAuth2Handler {
@@ -169,8 +172,10 @@ impl OAuth2Handler {
 
         let redirect_url = RedirectUrl::new(redirect_url.to_string())?;
 
-        // Perform OIDC discovery and build the client from provider metadata
-        let client = Self::discover_client(
+        // Perform OIDC discovery and build the client from provider metadata.
+        // The same discovery fetch also yields the optional RP-initiated logout
+        // endpoint, which the openidconnect client does not expose.
+        let (client, end_session_endpoint) = Self::discover_client(
             &issuer_url,
             &client_id,
             client_secret.as_ref(),
@@ -187,29 +192,56 @@ impl OAuth2Handler {
             settings: Arc::new(settings.clone()),
             issuer_url,
             http_client,
+            end_session_endpoint,
         })
     }
 
     /// Perform OIDC discovery and build a configured client from the fetched
-    /// provider metadata (which includes the current JWKS signing keys).
+    /// provider metadata (which includes the current JWKS signing keys). Also
+    /// returns the optional `end_session_endpoint` (RP-Initiated Logout 1.0)
+    /// read from the same discovery document.
     async fn discover_client(
         issuer_url: &IssuerUrl,
         client_id: &ClientId,
         client_secret: Option<&ClientSecret>,
         redirect_url: &RedirectUrl,
         http_client: &reqwest::Client,
-    ) -> Result<ConfiguredCoreClient, OAuth2Error> {
+    ) -> Result<(ConfiguredCoreClient, Option<String>), OAuth2Error> {
         let provider_metadata =
-            CoreProviderMetadata::discover_async(issuer_url.clone(), http_client)
+            ProviderMetadataWithLogout::discover_async(issuer_url.clone(), http_client)
                 .await
                 .map_err(|e| OAuth2Error::DiscoveryError(e.to_string()))?;
 
-        Ok(CoreClient::from_provider_metadata(
+        let end_session_endpoint = provider_metadata
+            .additional_metadata()
+            .end_session_endpoint
+            .as_ref()
+            .map(ToString::to_string);
+
+        let client = CoreClient::from_provider_metadata(
             provider_metadata,
             client_id.clone(),
             client_secret.cloned(),
         )
-        .set_redirect_uri(redirect_url.clone()))
+        .set_redirect_uri(redirect_url.clone());
+
+        Ok((client, end_session_endpoint))
+    }
+
+    /// Build the RP-initiated logout URL to end the provider session, or `None`
+    /// if the provider does not advertise an `end_session_endpoint`.
+    pub fn end_session_url(
+        &self,
+        id_token_hint: &str,
+        post_logout_redirect_uri: &str,
+    ) -> Option<String> {
+        let endpoint = self.end_session_endpoint.as_ref()?;
+        let mut url = Url::parse(endpoint).ok()?;
+        url.query_pairs_mut()
+            .append_pair("id_token_hint", id_token_hint)
+            .append_pair("client_id", self.client_id.as_str())
+            .append_pair("post_logout_redirect_uri", post_logout_redirect_uri);
+        Some(url.into())
     }
 
     fn current_client(&self) -> Arc<ConfiguredCoreClient> {
@@ -232,7 +264,7 @@ impl OAuth2Handler {
             &self.http_client,
         )
         .await
-        .map(Arc::new)
+        .map(|(client, _end_session_endpoint)| Arc::new(client))
     }
 
     /// Generate an authorization URL for the `OAuth2` flow
@@ -335,6 +367,7 @@ impl OAuth2Handler {
         Ok(TokenResult {
             claims,
             raw_payload,
+            id_token: id_token.to_string(),
         })
     }
 

--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -112,6 +112,11 @@ async fn run_server(resolved: ResolvedSettings) {
         std::process::exit(1);
     }
 
+    if let Err(e) = settings.oauth2.validate() {
+        eprintln!("Error: invalid OAuth2 configuration: {e}");
+        std::process::exit(1);
+    }
+
     let addr = SocketAddr::from((settings.local.ip, settings.local.port));
 
     // Configure tracing subscriber
@@ -401,24 +406,7 @@ async fn init_oauth2_handler(settings: &Settings) -> Option<Arc<OAuth2Handler>> 
         return None;
     }
 
-    // Construct the callback URL based on settings
-    let protocol = &settings.origin.protocol; // Protocol enum implements Display
-    let host = &settings.origin.hostname;
-    let port = settings.origin.port;
-
-    // FIX: Normalize path prefix to avoid double slashes
-    let raw_path = settings.origin.path.trim();
-    let path_prefix = if raw_path.is_empty() || raw_path == "/" {
-        String::new()
-    } else {
-        raw_path.trim_end_matches('/').to_string()
-    };
-
-    let callback_url = if port == 443 || port == 80 {
-        format!("{protocol}://{host}{path_prefix}/api/v1/oauth2/callback")
-    } else {
-        format!("{protocol}://{host}:{port}{path_prefix}/api/v1/oauth2/callback")
-    };
+    let callback_url = format!("{}/api/v1/oauth2/callback", settings.origin.base_url());
 
     match OAuth2Handler::from_discovery(&settings.oauth2, &callback_url).await {
         Ok(handler) => Some(Arc::new(handler)),

--- a/crates/settings/src/constants.rs
+++ b/crates/settings/src/constants.rs
@@ -5,3 +5,5 @@ pub const MIN_BODY_CRATE_AND_DOC_BYTES: usize = 10;
 pub const COOKIE_SESSION_ID: &str = "kellnr_session_id";
 
 pub const COOKIE_SESSION_USER: &str = "kellnr_session_user";
+
+pub const COOKIE_OIDC_ID_TOKEN: &str = "kellnr_oidc_id_token";

--- a/crates/settings/src/oauth2.rs
+++ b/crates/settings/src/oauth2.rs
@@ -17,6 +17,7 @@ fn default_button_text() -> String {
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, Configurable, ClapArgs)]
 #[serde(default)]
 #[configurable(clap_prefix = "oauth2")]
+#[allow(clippy::struct_excessive_bools)]
 pub struct OAuth2 {
     /// Enable `OAuth2`/OIDC authentication
     pub enabled: bool,
@@ -54,6 +55,12 @@ pub struct OAuth2 {
 
     /// Text displayed on the `OAuth2` login button
     pub button_text: String,
+
+    /// Enforce SSO-only login, disabling local password login/change/reset and user creation (requires `enabled`)
+    pub enforced: bool,
+
+    /// Skip the login page and redirect straight to the SSO provider (requires `enforced`)
+    pub auto_redirect: bool,
 }
 
 impl Default for OAuth2 {
@@ -70,6 +77,8 @@ impl Default for OAuth2 {
             read_only_group_claim: None,
             read_only_group_value: None,
             button_text: default_button_text(),
+            enforced: false,
+            auto_redirect: false,
         }
     }
 }
@@ -78,6 +87,18 @@ impl OAuth2 {
     /// Validate the `OAuth2` configuration
     /// Returns an error message if the configuration is invalid
     pub fn validate(&self) -> Result<(), String> {
+        if self.enforced && !self.enabled {
+            return Err("OAuth2 enforced is set but OAuth2 is not enabled; \
+                this would disable all login. Set oauth2.enabled = true"
+                .to_string());
+        }
+
+        if self.auto_redirect && !self.enforced {
+            return Err("OAuth2 auto_redirect is set but OAuth2 is not enforced; \
+                set oauth2.enforced = true to redirect straight to SSO"
+                .to_string());
+        }
+
         if !self.enabled {
             return Ok(());
         }
@@ -124,6 +145,8 @@ mod tests {
         assert_eq!(oauth2.scopes, vec!["openid", "profile", "email"]);
         assert!(oauth2.auto_provision_users);
         assert_eq!(oauth2.button_text, "Login with SSO");
+        assert!(!oauth2.enforced);
+        assert!(!oauth2.auto_redirect);
     }
 
     #[test]
@@ -193,6 +216,59 @@ mod tests {
         let result = oauth2.validate();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn test_validate_enforced_without_enabled() {
+        let oauth2 = OAuth2 {
+            enforced: true,
+            ..Default::default()
+        };
+        let result = oauth2.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("enforced"));
+    }
+
+    #[test]
+    fn test_validate_enforced_with_valid_enabled() {
+        let oauth2 = OAuth2 {
+            enabled: true,
+            enforced: true,
+            issuer_url: Some("https://example.com".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            ..Default::default()
+        };
+        assert!(oauth2.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_auto_redirect_without_enforced() {
+        let oauth2 = OAuth2 {
+            enabled: true,
+            auto_redirect: true,
+            issuer_url: Some("https://example.com".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            ..Default::default()
+        };
+        let result = oauth2.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("auto_redirect"));
+    }
+
+    #[test]
+    fn test_validate_auto_redirect_with_enforced() {
+        let oauth2 = OAuth2 {
+            enabled: true,
+            enforced: true,
+            auto_redirect: true,
+            issuer_url: Some("https://example.com".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            ..Default::default()
+        };
+        assert!(oauth2.validate().is_ok());
     }
 
     #[test]

--- a/crates/settings/src/origin.rs
+++ b/crates/settings/src/origin.rs
@@ -42,3 +42,17 @@ impl Default for Origin {
         }
     }
 }
+
+impl Origin {
+    pub fn base_url(&self) -> String {
+        let path_prefix = self.path.trim().trim_end_matches('/');
+        if self.port == 443 || self.port == 80 {
+            format!("{}://{}{}", self.protocol, self.hostname, path_prefix)
+        } else {
+            format!(
+                "{}://{}:{}{}",
+                self.protocol, self.hostname, self.port, path_prefix
+            )
+        }
+    }
+}

--- a/crates/web-ui/src/oauth2.rs
+++ b/crates/web-ui/src/oauth2.rs
@@ -15,12 +15,13 @@ use axum_extra::extract::PrivateCookieJar;
 use kellnr_appstate::{AppState, AppStateData, DbState, SettingsState};
 use kellnr_auth::oauth2::{OAuth2Handler, UserInfo, generate_unique_username};
 use kellnr_db::User;
+use kellnr_settings::constants::COOKIE_OIDC_ID_TOKEN;
 use serde::{Deserialize, Serialize};
 use tracing::{error, trace, warn};
 use utoipa::ToSchema;
 
 use crate::error::RouteError;
-use crate::session::create_session_jar;
+use crate::session::{create_session_jar, session_cookie};
 
 /// Type alias for the `OAuth2` handler extension
 pub type OAuth2Ext = Extension<Option<Arc<OAuth2Handler>>>;
@@ -32,6 +33,10 @@ pub struct OAuth2Config {
     pub enabled: bool,
     /// Text to display on the login button
     pub button_text: String,
+    /// Whether local password login is disabled (SSO-only)
+    pub enforced: bool,
+    /// Whether the login page should redirect straight to the SSO provider
+    pub auto_redirect: bool,
 }
 
 /// Query parameters received in the `OAuth2` callback
@@ -60,6 +65,8 @@ pub async fn get_config(State(settings): SettingsState) -> Json<OAuth2Config> {
     Json(OAuth2Config {
         enabled: settings.oauth2.enabled,
         button_text: settings.oauth2.button_text.clone(),
+        enforced: settings.oauth2.enforced,
+        auto_redirect: settings.oauth2.auto_redirect,
     })
 }
 
@@ -248,6 +255,11 @@ pub async fn callback(
     };
 
     let jar = create_session_jar(cookies, &app_state, &user.name).await?;
+    let jar = jar.add(session_cookie(
+        COOKIE_OIDC_ID_TOKEN,
+        token_result.id_token.clone(),
+        app_state.settings.registry.session_age_seconds as i64,
+    ));
     trace!("Created session for OAuth2 user: {}", user.name);
 
     // Redirect to UI root

--- a/crates/web-ui/src/session.rs
+++ b/crates/web-ui/src/session.rs
@@ -32,12 +32,23 @@ pub(crate) async fn create_session_jar(
             RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR)
         })?;
     let session_age_seconds = app_state.settings.registry.session_age_seconds as i64;
-    Ok(cookies.add(
-        Cookie::build((COOKIE_SESSION_ID, session_token))
-            .max_age(Duration::seconds(session_age_seconds))
-            .same_site(SameSite::Strict)
-            .path("/"),
-    ))
+    Ok(cookies.add(session_cookie(
+        COOKIE_SESSION_ID,
+        session_token,
+        session_age_seconds,
+    )))
+}
+
+pub(crate) fn session_cookie(
+    name: &'static str,
+    value: String,
+    session_age_seconds: i64,
+) -> Cookie<'static> {
+    Cookie::build((name, value))
+        .max_age(Duration::seconds(session_age_seconds))
+        .same_site(SameSite::Strict)
+        .path("/")
+        .into()
 }
 
 pub trait Name {

--- a/crates/web-ui/src/user.rs
+++ b/crates/web-ui/src/user.rs
@@ -1,19 +1,29 @@
-use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
+use axum::{Extension, Json};
 use axum_extra::extract::PrivateCookieJar;
 use axum_extra::extract::cookie::Cookie;
-use kellnr_appstate::{AppState, DbState, TokenCacheState};
+use kellnr_appstate::{AppState, DbState, SettingsState, TokenCacheState};
 use kellnr_auth::token;
 use kellnr_common::util::generate_rand_string;
 use kellnr_db::password::generate_salt;
 use kellnr_db::{self, AuthToken, User};
-use kellnr_settings::constants::{COOKIE_SESSION_ID, COOKIE_SESSION_USER};
+use kellnr_settings::Settings;
+use kellnr_settings::constants::{COOKIE_OIDC_ID_TOKEN, COOKIE_SESSION_ID, COOKIE_SESSION_USER};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::error::RouteError;
+use crate::oauth2::OAuth2Ext;
 use crate::session::{AdminUser, MaybeUser, create_session_jar};
+
+/// Reject local password operations when SSO is enforced.
+fn ensure_local_auth_enabled(settings: &Settings) -> Result<(), RouteError> {
+    if settings.oauth2.enforced {
+        return Err(RouteError::Status(StatusCode::FORBIDDEN));
+    }
+    Ok(())
+}
 
 #[derive(Serialize, ToSchema)]
 pub struct NewTokenResponse {
@@ -146,7 +156,10 @@ pub async fn reset_pwd(
     user: AdminUser,
     Path(name): Path<String>,
     State(db): DbState,
+    State(settings): SettingsState,
 ) -> Result<Json<ResetPwd>, RouteError> {
+    ensure_local_auth_enabled(&settings)?;
+
     let new_pwd = generate_rand_string(12);
     db.change_pwd(&name, &new_pwd).await?;
 
@@ -312,6 +325,7 @@ pub async fn login(
     State(state): AppState,
     Json(credentials): Json<Credentials>,
 ) -> Result<(PrivateCookieJar, Json<LoggedInUser>), RouteError> {
+    ensure_local_auth_enabled(&state.settings)?;
     credentials.validate()?;
 
     let user = state
@@ -364,29 +378,44 @@ pub async fn login_state(user: Option<MaybeUser>) -> Json<LoggedInUser> {
     .into()
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct LogoutResponse {
+    pub logout_url: Option<String>,
+}
+
 /// Logout and clear session
 #[utoipa::path(
     post,
     path = "/logout",
     tag = "auth",
     responses(
-        (status = 200, description = "Successfully logged out")
+        (status = 200, description = "Successfully logged out", body = LogoutResponse)
     )
 )]
 pub async fn logout(
     mut jar: PrivateCookieJar,
     State(state): AppState,
-) -> Result<PrivateCookieJar, RouteError> {
+    Extension(oauth2_handler): OAuth2Ext,
+) -> Result<(PrivateCookieJar, Json<LogoutResponse>), RouteError> {
     let session_id = match jar.get(COOKIE_SESSION_ID) {
         Some(c) => c.value().to_owned(),
-        None => return Ok(jar), // Already logged out as no cookie can be found
+        None => return Ok((jar, Json(LogoutResponse { logout_url: None }))),
     };
+
+    let logout_url = jar
+        .get(COOKIE_OIDC_ID_TOKEN)
+        .zip(oauth2_handler.as_ref())
+        .and_then(|(id_token, handler)| {
+            let post_logout = format!("{}/", state.settings.origin.base_url());
+            handler.end_session_url(id_token.value(), &post_logout)
+        });
 
     jar = jar.remove(COOKIE_SESSION_ID);
     jar = jar.remove(Cookie::build((COOKIE_SESSION_USER, "")).path("/"));
+    jar = jar.remove(Cookie::build((COOKIE_OIDC_ID_TOKEN, "")).path("/"));
 
     state.db.delete_session_token(&session_id).await?;
-    Ok(jar)
+    Ok((jar, Json(LogoutResponse { logout_url })))
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -427,8 +456,10 @@ impl PwdChange {
 pub async fn change_pwd(
     user: MaybeUser,
     State(db): DbState,
+    State(settings): SettingsState,
     Json(pwd_change): Json<PwdChange>,
 ) -> Result<(), RouteError> {
+    ensure_local_auth_enabled(&settings)?;
     pwd_change.validate()?;
 
     let Ok(user) = db.authenticate_user(user.name(), &pwd_change.old_pwd).await else {
@@ -482,8 +513,10 @@ pub async fn add(
     _user: AdminUser,
     State(db): DbState,
     State(cache): TokenCacheState,
+    State(settings): SettingsState,
     Json(new_user): Json<NewUser>,
 ) -> Result<(), RouteError> {
+    ensure_local_auth_enabled(&settings)?;
     new_user.validate()?;
 
     let salt = generate_salt();

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -157,6 +157,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -168,6 +169,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -178,6 +180,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -191,6 +194,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -207,6 +211,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -223,6 +228,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -239,6 +245,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -255,6 +262,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -271,6 +279,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -287,6 +296,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -303,6 +313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -319,6 +330,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -335,6 +347,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -351,6 +364,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -367,6 +381,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -383,6 +398,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -399,6 +415,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -415,6 +432,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -431,6 +449,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -447,6 +466,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -463,6 +483,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -479,6 +500,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -495,6 +517,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -511,6 +534,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -527,6 +551,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -543,6 +568,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -559,6 +585,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -575,6 +602,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -591,6 +619,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -841,6 +870,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -872,6 +902,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -888,6 +919,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,6 +936,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -920,6 +953,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -936,6 +970,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,6 +987,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -968,6 +1004,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -984,6 +1021,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1000,6 +1038,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1016,6 +1055,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1032,6 +1072,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1048,6 +1089,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,6 +1106,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1082,6 +1125,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1098,6 +1142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,6 +1163,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1155,7 +1201,7 @@
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
       "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2060,7 +2106,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2445,6 +2491,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2792,6 +2839,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2812,6 +2860,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2832,6 +2881,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2852,6 +2902,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2872,6 +2923,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2892,6 +2944,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2912,6 +2965,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2932,6 +2986,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2952,6 +3007,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2972,6 +3028,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2992,6 +3049,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3659,6 +3717,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -3723,7 +3782,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unplugin": {

--- a/ui/src/components/LoginButton.vue
+++ b/ui/src/components/LoginButton.vue
@@ -59,6 +59,10 @@ async function logOut() {
     const result = await userService.logout()
     if (isSuccess(result)) {
       store.logout()
+      if (result.data?.logout_url) {
+        window.location.href = result.data.logout_url
+        return
+      }
       router.push("/")
       showNotification("Successfully logged out")
     } else {

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,6 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { auth_required } from "../common/auth";
 import { useStore } from "../store/store";
+import { settingsService } from "../services";
+import { isSuccess } from "../services/api";
+import { OAUTH2_LOGIN } from "../remote-routes";
 
 const Crates = () => import("../views/Crates.vue")
 const Login = () => import("../views/Login.vue")
@@ -98,6 +101,15 @@ router.beforeEach(async (to) => {
     } else {
       // Not logged in - go to login with redirect flag
       return { name: 'Login', query: { redirect: 'me' } }
+    }
+  }
+
+  // With auto_redirect enabled, skip the login page and go straight to the provider.
+  if (to.name === 'Login' && !('error' in to.query)) {
+    const cfg = await settingsService.getOAuth2Config()
+    if (isSuccess(cfg) && cfg.data.enabled && cfg.data.auto_redirect) {
+      window.location.href = OAUTH2_LOGIN
+      return false
     }
   }
 

--- a/ui/src/services/settingsService.ts
+++ b/ui/src/services/settingsService.ts
@@ -1,7 +1,7 @@
 /**
  * Settings API service
  */
-import { apiGet } from './api'
+import { apiGet, isSuccess } from './api'
 import type { ApiResult } from '../types/api'
 import type { DocsEnabled, Settings, Version } from '../types/settings'
 import type { OAuth2Config } from '../types/oauth2'
@@ -38,8 +38,17 @@ export async function getVersion(): Promise<ApiResult<Version>> {
  * Get OAuth2/OIDC configuration
  * Returns whether OAuth2 is enabled and the button text to display
  */
+let oauth2ConfigCache: OAuth2Config | null = null
+
 export async function getOAuth2Config(): Promise<ApiResult<OAuth2Config>> {
-  return apiGet<OAuth2Config>(OAUTH2_CONFIG, undefined, {
+  if (oauth2ConfigCache) {
+    return { data: oauth2ConfigCache, error: null }
+  }
+  const result = await apiGet<OAuth2Config>(OAUTH2_CONFIG, undefined, {
     redirectOnAuthError: false,
   })
+  if (isSuccess(result)) {
+    oauth2ConfigCache = result.data
+  }
+  return result
 }

--- a/ui/src/services/userService.ts
+++ b/ui/src/services/userService.ts
@@ -8,6 +8,7 @@ import type {
   UserCredentials,
   LoginCredentials,
   LoginResponse,
+  LogoutResponse,
   PasswordResetResponse,
   ReadOnlyRequest,
   AdminRequest,
@@ -104,8 +105,8 @@ export async function login(credentials: LoginCredentials): Promise<ApiResult<Lo
 /**
  * Logout the current user
  */
-export async function logout(): Promise<ApiResult<void>> {
-  return apiPost<void>(LOGOUT, null, undefined, {
+export async function logout(): Promise<ApiResult<LogoutResponse>> {
+  return apiPost<LogoutResponse>(LOGOUT, null, undefined, {
     redirectOnAuthError: false,
   })
 }

--- a/ui/src/types/oauth2.ts
+++ b/ui/src/types/oauth2.ts
@@ -10,4 +10,8 @@ export interface OAuth2Config {
   enabled: boolean
   /** Text to display on the OAuth2 login button */
   button_text: string
+  /** Whether local password login is disabled (SSO-only) */
+  enforced: boolean
+  /** Whether the login page should redirect straight to the SSO provider */
+  auto_redirect: boolean
 }

--- a/ui/src/types/user.ts
+++ b/ui/src/types/user.ts
@@ -31,6 +31,10 @@ export interface PasswordResetResponse {
   new_pwd: string
 }
 
+export interface LogoutResponse {
+  logout_url: string | null
+}
+
 export interface ReadOnlyRequest {
   state: boolean
 }

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -11,7 +11,12 @@
 
           <!-- Form -->
           <v-card-text class="pa-6 pt-2">
-            <v-form ref="form" @submit.prevent="handleLogin" v-model="isFormValid">
+            <v-form
+              v-if="!ssoEnforced"
+              ref="form"
+              @submit.prevent="handleLogin"
+              v-model="isFormValid"
+            >
               <div class="input-group">
                 <label class="input-label">Username</label>
                 <v-text-field
@@ -81,7 +86,7 @@
 
             <!-- OAuth2/SSO Login -->
             <template v-if="oauth2Enabled">
-              <div class="oauth2-divider">
+              <div v-if="!ssoEnforced" class="oauth2-divider">
                 <span>or</span>
               </div>
 
@@ -125,6 +130,7 @@ const store = useStore()
 // OAuth2 state
 const oauth2Enabled = ref(false)
 const oauth2ButtonText = ref("Login with SSO")
+const ssoEnforced = ref(false)
 
 // Composables
 const status = useStatusMessage()
@@ -153,11 +159,12 @@ onMounted(async () => {
     }
   }
 
-  // Fetch OAuth2 configuration
+  // Fetch OAuth2 configuration (auto_redirect is handled by the router guard)
   const oauth2Result = await settingsService.getOAuth2Config()
   if (isSuccess(oauth2Result)) {
     oauth2Enabled.value = oauth2Result.data.enabled
     oauth2ButtonText.value = oauth2Result.data.button_text
+    ssoEnforced.value = oauth2Result.data.enforced
   }
 })
 


### PR DESCRIPTION
## Summary

Adds two new OAuth2/OIDC settings that let an operator make SSO the sole authentication path:

- `oauth2.enforced` — disables local password login, change, reset, and user creation, so the only way in is via the SSO provider.
- `oauth2.auto_redirect` — skips the Kellnr login page entirely and sends the browser straight to the provider (requires `enforced`).

It also wires up RP-Initiated Logout so signing out of Kellnr can end the upstream provider session too.

## Changes

- Settings: add `enforced` / `auto_redirect` flags with `validate()` guards (`enforced` requires `enabled`; `auto_redirect` requires `enforced`), validated at startup in `main.rs`. Extract origin URL building into `Origin::base_url()`, replacing the ad-hoc callback-URL construction.
- Backend enforcement: `ensure_local_auth_enabled` rejects the local password routes (`login`, `add`, `reset_pwd`, `change_pwd`) with 403 when SSO is enforced.
- RP-initiated logout: read the provider's `end_session_endpoint` from the existing discovery fetch (via a custom `RpLogoutMetadata` provider metadata type — no extra round-trip), store the raw ID token in an encrypted cookie at callback, and have `logout` return an `end_session_url` for the UI to redirect to.
- Frontend: expose the new config, hide the password form and redirect from the login page when enforced/auto_redirect, follow the logout URL, and cache the OAuth2 config lookup.

## Test

- New `validate()` unit tests covering the enforced/auto_redirect dependency rules.
- Existing settings and auth suites still pass.