### PR TITLE
build: bump rust-overlay to unblock rustc 1.95+ toolchain

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775531562,
-        "narHash": "sha256-G83GDxQo6lqO5aeTSD5RFLhnh2g6DzJpSvSju2EjjrQ=",
+        "lastModified": 1783834461,
+        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d8b1b209203665924c81eabf750492530754f27e",
+        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

CI is pinned to rustc 1.94.1 via the flake-locked `rust-overlay` revision. `cargo@0.98.0` (and `cargo-credential-libsecret@0.5.8`, `crates-io@0.41.0`) now require rustc 1.95, so #1276 (a Dependabot bump of the `cargo` crate to 0.98.0) fails every CI job at dependency resolution:

```
error: rustc 1.94.1 is not supported by the following packages:
  cargo@0.98.0 requires rustc 1.95
  cargo-credential-libsecret@0.5.8 requires rustc 1.95
  crates-io@0.41.0 requires rustc 1.95
```

## Changes

- `flake.lock`: update the `rust-overlay` input so `pkgs.rust-bin.stable.latest` resolves to rustc 1.97.0 (was 1.94.1). No other inputs changed.

## Test plan

- [x] `nix flake check` passes
- [x] `nix develop --command rustc --version` reports `rustc 1.97.0`
- [ ] CI green on this PR
- [ ] Rebase/retrigger #1276 once merged to confirm it now passes