### PR TITLE
ci: hold TypeScript on 6.x + fix clippy::map_unwrap_or on newer clippy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
       npm-all:
         patterns:
           - "*"
+    # TypeScript 7 (native Go compiler) has no stable programmatic API yet,
+    # so vue-tsc/Volar and typescript-eslint can't run on it. Stay on TS 6.x
+    # (minor/patch bumps still allowed). Revisit once TS 7.1 ships (~Q4 2026)
+    # and both vue-tsc and typescript-eslint declare support.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Two related CI fixes

### 1. Hold TypeScript on 6.x (Dependabot)

The grouped npm Dependabot PR #1278 fails **all 5 CI jobs**. Every job runs `just npm-build` first, which dies at `npm install`:

```
npm error ERESOLVE could not resolve
npm error Conflicting peer dependency: typescript@6.0.3
npm error peer typescript@">=4.8.4 <6.1.0" from typescript-eslint@8.63.0
```

The group bumped `typescript` `~6.0.3` → `~7.0.2` (a major), but `typescript-eslint` only supports `typescript >=4.8.4 <6.1.0`.

**Why not just move to TS 7:** TypeScript 7 is the native (Go) compiler, GA 2026-07-08, but it ships **without a stable programmatic API**. Every tool that embeds the TS compiler lags — `vue-tsc`/Volar (our `type-check`, [vuejs/language-tools#5381](https://github.com/vuejs/language-tools/issues/5381)) and `typescript-eslint` (our `lint`, [typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)). Stable API is expected in **TS 7.1 (~Q4 2026)**.

Adds an `ignore` rule to `.github/dependabot.yml` pinning TypeScript to its 6.x major. Minor/patch (6.0.x) bumps still flow.

### 2. Fix `clippy::map_unwrap_or` (unblocks all CI)

While validating, CI's Clippy job was *also* failing — independent of the npm issue. Clippy 1.97 (pulled via `nixos-unstable`) promotes `clippy::map_unwrap_or`, which fires on the `SystemTime` fallback in `crates/auth/src/oauth2.rs`. With the repo's `-D warnings`, this failed **every** PR against `main`, not just this one. Fixed with the clippy-suggested `map_or`. Validated locally with clippy `0.1.97` (same version as CI): `cargo clippy --workspace --all-targets --all-features -- --deny warnings` passes.

## Follow-up

Once merged, comment `@dependabot recreate` on #1278 so the group PR is rebuilt without the TS 7 major.

When TS 7.1 lands, remove the `ignore` block and bump `typescript` + `vue-tsc` + `typescript-eslint` together.