### PR TITLE
chore: release v6.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "chrono",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "cargo",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "bytes",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "chrono",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "async-std",
  "chrono",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "bytes",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.5.2"
+version = "6.5.3"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.5.2"
+version = "6.5.3"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.5.2", path = "./crates/appstate" }
-kellnr-auth = { version = "6.5.2", path = "./crates/auth" }
-kellnr-common = { version = "6.5.2", path = "./crates/common" }
-kellnr-db = { version = "6.5.2", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.5.2", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.5.2", path = "./crates/docs" }
-kellnr-entity = { version = "6.5.2", path = "./crates/db/entity" }
-kellnr-error = { version = "6.5.2", path = "./crates/error" }
-kellnr-index = { version = "6.5.2", path = "./crates/index" }
-kellnr-migration = { version = "6.5.2", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.5.2", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.5.2", path = "./crates/registry" }
-kellnr-settings = { version = "6.5.2", path = "./crates/settings" }
-kellnr-storage = { version = "6.5.2", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.5.2", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.5.2", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.5.2", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.5.3", path = "./crates/appstate" }
+kellnr-auth = { version = "6.5.3", path = "./crates/auth" }
+kellnr-common = { version = "6.5.3", path = "./crates/common" }
+kellnr-db = { version = "6.5.3", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.5.3", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.5.3", path = "./crates/docs" }
+kellnr-entity = { version = "6.5.3", path = "./crates/db/entity" }
+kellnr-error = { version = "6.5.3", path = "./crates/error" }
+kellnr-index = { version = "6.5.3", path = "./crates/index" }
+kellnr-migration = { version = "6.5.3", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.5.3", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.5.3", path = "./crates/registry" }
+kellnr-settings = { version = "6.5.3", path = "./crates/settings" }
+kellnr-storage = { version = "6.5.3", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.5.3", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.5.3", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.5.3", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.5.3

This release updates all workspace packages to version **6.5.3**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-rustfs-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [6.5.3](https://github.com/kellnr/kellnr/compare/v6.5.2...v6.5.3) - 2026-07-28

### Fixed

- macos build expecting xz installed via Homebrew ([#1311](https://github.com/kellnr/kellnr/pull/1311))

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
