### PR TITLE
chore: release v6.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "quote",
  "syn 3.0.3",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "cargo",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "quote",
  "syn 3.0.3",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4552,7 +4552,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.5.3"
+version = "6.6.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "chrono",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "cargo",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "bytes",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "chrono",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "async-std",
  "chrono",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "bytes",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.5.3"
+version = "6.5.4"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.5.3"
+version = "6.6.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.5.3", path = "./crates/appstate" }
-kellnr-auth = { version = "6.5.3", path = "./crates/auth" }
-kellnr-common = { version = "6.5.3", path = "./crates/common" }
-kellnr-db = { version = "6.5.3", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.5.3", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.5.3", path = "./crates/docs" }
-kellnr-entity = { version = "6.5.3", path = "./crates/db/entity" }
-kellnr-error = { version = "6.5.3", path = "./crates/error" }
-kellnr-index = { version = "6.5.3", path = "./crates/index" }
-kellnr-migration = { version = "6.5.3", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.5.3", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.5.3", path = "./crates/registry" }
-kellnr-settings = { version = "6.5.3", path = "./crates/settings" }
-kellnr-storage = { version = "6.5.3", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.5.3", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.5.3", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.5.3", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.6.0", path = "./crates/appstate" }
+kellnr-auth = { version = "6.6.0", path = "./crates/auth" }
+kellnr-common = { version = "6.6.0", path = "./crates/common" }
+kellnr-db = { version = "6.6.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.6.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.6.0", path = "./crates/docs" }
+kellnr-entity = { version = "6.6.0", path = "./crates/db/entity" }
+kellnr-error = { version = "6.6.0", path = "./crates/error" }
+kellnr-index = { version = "6.6.0", path = "./crates/index" }
+kellnr-migration = { version = "6.6.0", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.6.0", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.6.0", path = "./crates/registry" }
+kellnr-settings = { version = "6.6.0", path = "./crates/settings" }
+kellnr-storage = { version = "6.6.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.6.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.6.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.6.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.5.3"
+version = "6.5.4"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,23 +17,23 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.5.3", path = "./crates/appstate" }
-kellnr-auth = { version = "6.5.3", path = "./crates/auth" }
-kellnr-common = { version = "6.5.3", path = "./crates/common" }
-kellnr-db = { version = "6.5.3", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.5.3", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.5.3", path = "./crates/docs" }
-kellnr-entity = { version = "6.5.3", path = "./crates/db/entity" }
-kellnr-error = { version = "6.5.3", path = "./crates/error" }
-kellnr-index = { version = "6.5.3", path = "./crates/index" }
-kellnr-migration = { version = "6.5.3", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.5.3", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.5.3", path = "./crates/registry" }
-kellnr-settings = { version = "6.5.3", path = "./crates/settings" }
-kellnr-storage = { version = "6.5.3", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.5.3", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.5.3", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.5.3", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.5.4", path = "./crates/appstate" }
+kellnr-auth = { version = "6.5.4", path = "./crates/auth" }
+kellnr-common = { version = "6.5.4", path = "./crates/common" }
+kellnr-db = { version = "6.5.4", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.5.4", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.5.4", path = "./crates/docs" }
+kellnr-entity = { version = "6.5.4", path = "./crates/db/entity" }
+kellnr-error = { version = "6.5.4", path = "./crates/error" }
+kellnr-index = { version = "6.5.4", path = "./crates/index" }
+kellnr-migration = { version = "6.5.4", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.5.4", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.5.4", path = "./crates/registry" }
+kellnr-settings = { version = "6.5.4", path = "./crates/settings" }
+kellnr-storage = { version = "6.5.4", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.5.4", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.5.4", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.5.4", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.6.0

This release updates all workspace packages to version **6.6.0**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-rustfs-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [6.6.0](https://github.com/kellnr/kellnr/compare/v6.5.3...v6.6.0) - 2026-08-17

### Added

- *(kellnr)* add baseline security headers to all responses

### Fixed

- *(ui)* bundle highlight.js theme CSS instead of loading from CDN
- *(web-ui)* widen session token to 32 chars
- *(db)* escape LIKE wildcards in crate search
- *(webhooks)* add connect/request timeouts to webhook HTTP clients
- *(web-ui)* return the reset user's name from reset_pwd
- *(kellnr)* apply restrictive CSP to user-uploaded docs
- *(common)* validate OriginalName on deserialize
- *(registry)* bounds-check publish payload parser
- *(web-ui)* set HttpOnly and Secure flags on session cookie

### Other

- *(ui)* remove dead highlight.js theme-link toggling
- *(ui)* drop redundant highlight.js theme CSS import
- *(db)* backtick DoS in escape_like_pattern doc comment
- update flake.nix
- *(deps)* bump hyper from 1.10.1 to 1.11.0 ([#1337](https://github.com/kellnr/kellnr/pull/1337))
- *(deps)* bump the npm-all group in /ui with 7 updates ([#1335](https://github.com/kellnr/kellnr/pull/1335))
- *(deps)* bump hyper from 1.10.1 to 1.11.0
- *(deps)* bump sea-orm-migration from 2.0.0 to 2.0.1 ([#1336](https://github.com/kellnr/kellnr/pull/1336))
- *(deps)* bump moka from 0.12.15 to 0.12.16 ([#1334](https://github.com/kellnr/kellnr/pull/1334))
- *(deps)* bump async-trait from 0.1.91 to 0.1.92 ([#1333](https://github.com/kellnr/kellnr/pull/1333))
- *(deps)* bump thiserror from 2.0.19 to 2.0.20 ([#1332](https://github.com/kellnr/kellnr/pull/1332))
- *(deps)* bump taiki-e/install-action from 2.85.8 to 2.85.12 ([#1331](https://github.com/kellnr/kellnr/pull/1331))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump sea-orm-migration from 2.0.0 to 2.0.1
- *(deps)* bump the npm-all group in /ui with 7 updates
- *(deps)* bump moka from 0.12.15 to 0.12.16
- *(deps)* bump async-trait from 0.1.91 to 0.1.92
- *(deps)* bump thiserror from 2.0.19 to 2.0.20
- *(deps)* bump taiki-e/install-action from 2.85.8 to 2.85.12
- update syn dependency
- *(deps)* bump sea-orm from 2.0.0 to 2.0.1 ([#1329](https://github.com/kellnr/kellnr/pull/1329))
- *(deps)* bump base64 from 0.23.0 to 0.23.1 ([#1328](https://github.com/kellnr/kellnr/pull/1328))
- *(deps)* bump the npm-all group in /ui with 10 updates ([#1325](https://github.com/kellnr/kellnr/pull/1325))
- *(deps)* bump sea-orm from 2.0.0 to 2.0.1
- *(deps)* bump time from 0.3.54 to 0.3.55 ([#1326](https://github.com/kellnr/kellnr/pull/1326))
- *(deps)* bump tokio from 1.53.0 to 1.53.1 ([#1324](https://github.com/kellnr/kellnr/pull/1324))
- *(deps)* bump taiki-e/install-action from 2.85.4 to 2.85.8 ([#1323](https://github.com/kellnr/kellnr/pull/1323))
- *(deps)* bump base64 from 0.23.0 to 0.23.1
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump time from 0.3.54 to 0.3.55
- *(deps)* bump the npm-all group in /ui with 10 updates
- *(deps)* bump tokio from 1.53.0 to 1.53.1
- *(deps)* bump taiki-e/install-action from 2.85.4 to 2.85.8
- *(deps)* bump postcss from 8.5.19 to 8.5.25 in /ui ([#1322](https://github.com/kellnr/kellnr/pull/1322))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump postcss from 8.5.19 to 8.5.25 in /ui
- *(deps-dev)* bump undici from 8.7.0 to 8.10.0 in /tests ([#1321](https://github.com/kellnr/kellnr/pull/1321))
- *(deps-dev)* bump undici from 8.7.0 to 8.10.0 in /tests
- *(deps)* bump base64 from 0.22.1 to 0.23.0 ([#1315](https://github.com/kellnr/kellnr/pull/1315))
- *(deps)* bump base64 from 0.22.1 to 0.23.0
- *(deps)* bump quote from 1.0.46 to 1.0.47 ([#1318](https://github.com/kellnr/kellnr/pull/1318))
- *(deps)* bump sea-orm-migration from 2.0.0-rc.43 to 2.0.0 ([#1317](https://github.com/kellnr/kellnr/pull/1317))
- *(deps)* bump serde_json from 1.0.150 to 1.0.151 ([#1319](https://github.com/kellnr/kellnr/pull/1319))
- *(deps-dev)* bump the npm-all group in /ui with 2 updates ([#1314](https://github.com/kellnr/kellnr/pull/1314))
- *(deps)* bump sea-orm-migration from 2.0.0-rc.43 to 2.0.0
- *(deps)* bump quote from 1.0.46 to 1.0.47
- *(deps)* bump clap from 4.6.1 to 4.6.4 ([#1316](https://github.com/kellnr/kellnr/pull/1316))
- *(deps)* bump taiki-e/install-action from 2 to 2.85.4 ([#1313](https://github.com/kellnr/kellnr/pull/1313))
- *(deps)* bump serde_json from 1.0.150 to 1.0.151
- *(deps)* bump clap from 4.6.1 to 4.6.4
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps-dev)* bump the npm-all group in /ui with 2 updates
- *(deps)* bump taiki-e/install-action from 2 to 2.85.4

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
