### PR TITLE
chore: release v6.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-appstate"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-auth"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4293,7 +4293,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-common"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "chrono",
  "kellnr-common",
@@ -4337,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-db-testcontainer"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "quote",
  "syn 3.0.4",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-docs"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "cargo",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-embedded-resources"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-entity"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "sea-orm",
  "uuid",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-error"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "kellnr-common",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-fakegcs-testcontainer"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "quote",
  "syn 3.0.4",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-index"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-migration"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "async-std",
  "chrono",
@@ -4456,7 +4456,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-registry"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "bytes",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-rustfs-testcontainer"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "quote",
  "syn 3.0.4",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-settings"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "clap",
  "kellnr-common",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-storage"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-web-ui"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "kellnr-webhooks"
-version = "6.7.0"
+version = "6.8.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 authors = ["kellnr.io"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-version = "6.7.0"
+version = "6.8.0"
 description = "Kellnr is a self-hosted registry for Rust crates with support for rustdocs and crates.io caching."
 homepage = "https://kellnr.io/"
 repository = "https://github.com/kellnr/kellnr"
@@ -17,24 +17,24 @@ keywords = ["cargo", "registry", "crates-io", "self-hosted"]
 
 [workspace.dependencies]
 # Internal dependencies from Kellnr
-kellnr-appstate = { version = "6.7.0", path = "./crates/appstate" }
-kellnr-auth = { version = "6.7.0", path = "./crates/auth" }
-kellnr-common = { version = "6.7.0", path = "./crates/common" }
-kellnr-db = { version = "6.7.0", path = "./crates/db" }
-kellnr-db-testcontainer = { version = "6.7.0", path = "./crates/db/db-testcontainer" }
-kellnr-docs = { version = "6.7.0", path = "./crates/docs" }
-kellnr-entity = { version = "6.7.0", path = "./crates/db/entity" }
-kellnr-error = { version = "6.7.0", path = "./crates/error" }
-kellnr-fakegcs-testcontainer = { version = "6.7.0", path = "./crates/storage/fakegcs-testcontainer" }
-kellnr-index = { version = "6.7.0", path = "./crates/index" }
-kellnr-migration = { version = "6.7.0", path = "./crates/db/migration" }
-kellnr-rustfs-testcontainer = { version = "6.7.0", path = "./crates/storage/rustfs-testcontainer" }
-kellnr-registry = { version = "6.7.0", path = "./crates/registry" }
-kellnr-settings = { version = "6.7.0", path = "./crates/settings" }
-kellnr-storage = { version = "6.7.0", path = "./crates/storage" }
-kellnr-web-ui = { version = "6.7.0", path = "./crates/web-ui" }
-kellnr-webhooks = { version = "6.7.0", path = "./crates/webhooks" }
-kellnr-embedded-resources = { version = "6.7.0", path = "./crates/embedded-resources" }
+kellnr-appstate = { version = "6.8.0", path = "./crates/appstate" }
+kellnr-auth = { version = "6.8.0", path = "./crates/auth" }
+kellnr-common = { version = "6.8.0", path = "./crates/common" }
+kellnr-db = { version = "6.8.0", path = "./crates/db" }
+kellnr-db-testcontainer = { version = "6.8.0", path = "./crates/db/db-testcontainer" }
+kellnr-docs = { version = "6.8.0", path = "./crates/docs" }
+kellnr-entity = { version = "6.8.0", path = "./crates/db/entity" }
+kellnr-error = { version = "6.8.0", path = "./crates/error" }
+kellnr-fakegcs-testcontainer = { version = "6.8.0", path = "./crates/storage/fakegcs-testcontainer" }
+kellnr-index = { version = "6.8.0", path = "./crates/index" }
+kellnr-migration = { version = "6.8.0", path = "./crates/db/migration" }
+kellnr-rustfs-testcontainer = { version = "6.8.0", path = "./crates/storage/rustfs-testcontainer" }
+kellnr-registry = { version = "6.8.0", path = "./crates/registry" }
+kellnr-settings = { version = "6.8.0", path = "./crates/settings" }
+kellnr-storage = { version = "6.8.0", path = "./crates/storage" }
+kellnr-web-ui = { version = "6.8.0", path = "./crates/web-ui" }
+kellnr-webhooks = { version = "6.8.0", path = "./crates/webhooks" }
+kellnr-embedded-resources = { version = "6.8.0", path = "./crates/embedded-resources" }
 
 # External dependencies from crates.io
 async-trait = "0.1.89"


### PR DESCRIPTION

## New release v6.8.0

This release updates all workspace packages to version **6.8.0**.

### Packages updated

* `kellnr-common`
* `kellnr-db-testcontainer`
* `kellnr-entity`
* `kellnr-settings`
* `kellnr-migration`
* `kellnr-db`
* `kellnr-rustfs-testcontainer`
* `kellnr-storage`
* `kellnr-appstate`
* `kellnr-fakegcs-testcontainer`
* `kellnr-auth`
* `kellnr-error`
* `kellnr-webhooks`
* `kellnr-registry`
* `kellnr-docs`
* `kellnr-embedded-resources`
* `kellnr-index`
* `kellnr-web-ui`
* `kellnr`


<details><summary><i><b>Changelog</b></i></summary>

## [6.8.0](https://github.com/kellnr/kellnr/compare/v6.7.0...v6.8.0) - 2026-08-29

### Added

- *(storage)* add Google Cloud Storage backend support ([#1349](https://github.com/kellnr/kellnr/pull/1349))

### Other

- *(deps)* bump syn from 3.0.3 to 3.0.4 ([#1354](https://github.com/kellnr/kellnr/pull/1354))
- *(deps)* bump the npm-all group in /ui with 8 updates ([#1355](https://github.com/kellnr/kellnr/pull/1355))
- *(deps)* bump syn from 3.0.3 to 3.0.4
- *(deps)* bump sea-orm from 2.0.1 to 2.0.2 ([#1353](https://github.com/kellnr/kellnr/pull/1353))
- *(deps)* bump sea-query from 1.0.1 to 1.0.2 ([#1352](https://github.com/kellnr/kellnr/pull/1352))
- *(deps)* bump uuid from 1.24.1 to 1.25.0 ([#1351](https://github.com/kellnr/kellnr/pull/1351))
- *(deps)* bump taiki-e/install-action from 2.86.3 to 2.86.8 ([#1350](https://github.com/kellnr/kellnr/pull/1350))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump the npm-all group in /ui with 8 updates
- *(deps)* bump sea-orm from 2.0.1 to 2.0.2
- *(deps)* bump sea-query from 1.0.1 to 1.0.2
- *(deps)* bump uuid from 1.24.1 to 1.25.0
- *(deps)* bump taiki-e/install-action from 2.86.3 to 2.86.8
- *(deps)* bump testcontainers from 0.27.3 to 0.28.0 ([#1345](https://github.com/kellnr/kellnr/pull/1345))
- *(deps)* bump the npm-all group in /ui with 6 updates ([#1344](https://github.com/kellnr/kellnr/pull/1344))
- *(deps)* bump cookie from 0.18.1 to 0.18.2 ([#1346](https://github.com/kellnr/kellnr/pull/1346))
- *(deps)* bump testcontainers from 0.27.3 to 0.28.0
- *(deps)* bump http-body-util from 0.1.4 to 0.1.5 ([#1343](https://github.com/kellnr/kellnr/pull/1343))
- *(deps)* bump uuid from 1.24.0 to 1.24.1 ([#1341](https://github.com/kellnr/kellnr/pull/1341))
- *(deps)* bump taiki-e/install-action from 2.85.12 to 2.86.3 ([#1340](https://github.com/kellnr/kellnr/pull/1340))
- *(deps)* bump clap from 4.6.5 to 4.6.6 ([#1342](https://github.com/kellnr/kellnr/pull/1342))
- *(deps)* update npmDepsHash in flake.nix [dependabot skip]
- *(deps)* bump cookie from 0.18.1 to 0.18.2
- *(deps)* bump the npm-all group in /ui with 6 updates
- *(deps)* bump http-body-util from 0.1.4 to 0.1.5
- *(deps)* bump clap from 4.6.5 to 4.6.6
- *(deps)* bump uuid from 1.24.0 to 1.24.1
- *(deps)* bump taiki-e/install-action from 2.85.12 to 2.86.3

</details>




---
Generated by [k-releaser](https://github.com/secana/k-releaser/)
