### PR TITLE
fix(auth): allow configurable additional audiences

### DIFF
--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -306,8 +306,9 @@ impl OAuth2Handler {
 
         let nonce = Nonce::new(nonce.to_string());
 
-        // An ID token may contain multiple audiences. When configured, accept
-        // additional audiences while requiring the configured client ID.
+        // An ID token may contain multiple audiences. Require the configured
+        // client ID and accept additional audiences only when explicitly
+        // allowlisted.
         let verifier = client.id_token_verifier().set_other_audience_verifier_fn({
             let additional_audiences = self.settings.additional_audiences.clone();
             move |aud| {

--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -309,8 +309,12 @@ impl OAuth2Handler {
         // An ID token may contain multiple audiences. When configured, accept
         // additional audiences while requiring the configured client ID.
         let verifier = client.id_token_verifier().set_other_audience_verifier_fn({
-            let allow_additional_audiences = self.settings.allow_additional_audiences;
-            move |_| allow_additional_audiences
+            let additional_audiences = self.settings.additional_audiences.clone();
+            move |aud| {
+                additional_audiences
+                    .iter()
+                    .any(|allowed| allowed == aud.as_str())
+            }
         });
 
         let claims = match id_token.claims(&verifier, &nonce) {
@@ -327,9 +331,12 @@ impl OAuth2Handler {
                     let verifier = refreshed
                         .id_token_verifier()
                         .set_other_audience_verifier_fn({
-                            let allow_additional_audiences =
-                                self.settings.allow_additional_audiences;
-                            move |_| allow_additional_audiences
+                            let additional_audiences = self.settings.additional_audiences.clone();
+                            move |aud| {
+                                additional_audiences
+                                    .iter()
+                                    .any(|allowed| allowed == aud.as_str())
+                            }
                         });
                     id_token
                         .claims(&verifier, &nonce)
@@ -884,6 +891,8 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
         jwks_fetches: AtomicUsize,
         /// Whether the mock token includes the configured client ID in `aud`.
         include_client_audience: AtomicBool,
+        /// Whether the mock token includes the additional audience in `aud`.
+        include_other_audience: AtomicBool,
     }
 
     impl MockProvider {
@@ -897,14 +906,13 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
 
         /// Mint an ID token signed with the currently active key.
         fn sign_id_token(&self) -> String {
-            let audiences = if self.include_client_audience.load(Ordering::SeqCst) {
-                vec![
-                    Audience::new(OTHER_AUDIENCE.to_string()),
-                    Audience::new(CLIENT_ID.to_string()),
-                ]
-            } else {
-                vec![Audience::new(OTHER_AUDIENCE.to_string())]
-            };
+            let mut audiences = Vec::new();
+            if self.include_client_audience.load(Ordering::SeqCst) {
+                audiences.push(Audience::new(CLIENT_ID.to_string()));
+            }
+            if self.include_other_audience.load(Ordering::SeqCst) {
+                audiences.push(Audience::new(OTHER_AUDIENCE.to_string()));
+            }
 
             let claims = CoreIdTokenClaims::new(
                 IssuerUrl::new(self.issuer.clone()).unwrap(),
@@ -961,13 +969,13 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
         }))
     }
 
-    fn test_settings(issuer: &str, allow_additional_audiences: bool) -> OAuth2Settings {
+    fn test_settings(issuer: &str, additional_audiences: Vec<String>) -> OAuth2Settings {
         OAuth2Settings {
             enabled: true,
             issuer_url: Some(issuer.to_string()),
             client_id: Some(CLIENT_ID.to_string()),
             client_secret: Some("test-secret".to_string()),
-            allow_additional_audiences,
+            additional_audiences,
             ..Default::default()
         }
     }
@@ -994,6 +1002,7 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
             rotated: AtomicBool::new(false),
             jwks_fetches: AtomicUsize::new(0),
             include_client_audience: AtomicBool::new(true),
+            include_other_audience: AtomicBool::new(false),
         });
 
         let app = Router::new()
@@ -1009,7 +1018,7 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
 
         // Discovery caches key A (first JWKS fetch).
         let handler =
-            OAuth2Handler::from_discovery(&test_settings(&issuer, true), "http://localhost/cb")
+            OAuth2Handler::from_discovery(&test_settings(&issuer, vec![]), "http://localhost/cb")
                 .await
                 .expect("discovery should succeed");
         assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 1);
@@ -1045,33 +1054,62 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
         assert_eq!(result.claims.subject().as_str(), SUBJECT);
         assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 2);
 
-        // The client ID remains mandatory even when additional audiences are
-        // accepted.
+        // The client ID remains mandatory, even if an additional audience is
+        // otherwise trusted.
         provider
             .include_client_audience
             .store(false, Ordering::SeqCst);
-        assert!(
-            handler
-                .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
-                .await
-                .is_err()
-        );
+        provider
+            .include_other_audience
+            .store(true, Ordering::SeqCst);
+        let error = handler
+            .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+            .await
+            .expect_err("a token without the client audience must be rejected");
+        match error {
+            OAuth2Error::TokenVerificationError(message) => {
+                assert!(
+                    message.to_ascii_lowercase().contains("audience"),
+                    "{message}"
+                );
+            }
+            error => panic!("expected an audience verification error, got {error:?}"),
+        }
 
-        // Strict mode rejects an otherwise valid token when it contains an
-        // audience other than the configured client ID.
+        // An explicitly allowlisted additional audience is accepted.
         provider
             .include_client_audience
             .store(true, Ordering::SeqCst);
+        let allowlisted_handler = OAuth2Handler::from_discovery(
+            &test_settings(&issuer, vec![OTHER_AUDIENCE.to_string()]),
+            "http://localhost/cb",
+        )
+        .await
+        .expect("allowlisted discovery should succeed");
+        allowlisted_handler
+            .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+            .await
+            .expect("allowlisted audience should be accepted");
+
+        // Strict mode rejects an otherwise valid token when it contains an
+        // audience other than the configured client ID.
         let strict_handler =
-            OAuth2Handler::from_discovery(&test_settings(&issuer, false), "http://localhost/cb")
+            OAuth2Handler::from_discovery(&test_settings(&issuer, vec![]), "http://localhost/cb")
                 .await
                 .expect("strict discovery should succeed");
-        assert!(
-            strict_handler
-                .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
-                .await
-                .is_err()
-        );
+        let error = strict_handler
+            .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+            .await
+            .expect_err("an untrusted additional audience must be rejected");
+        match error {
+            OAuth2Error::TokenVerificationError(message) => {
+                assert!(
+                    message.to_ascii_lowercase().contains("audience"),
+                    "{message}"
+                );
+            }
+            error => panic!("expected an audience verification error, got {error:?}"),
+        }
 
         server.abort();
     }

--- a/crates/auth/src/oauth2.rs
+++ b/crates/auth/src/oauth2.rs
@@ -306,7 +306,14 @@ impl OAuth2Handler {
 
         let nonce = Nonce::new(nonce.to_string());
 
-        let claims = match id_token.claims(&client.id_token_verifier(), &nonce) {
+        // An ID token may contain multiple audiences. When configured, accept
+        // additional audiences while requiring the configured client ID.
+        let verifier = client.id_token_verifier().set_other_audience_verifier_fn({
+            let allow_additional_audiences = self.settings.allow_additional_audiences;
+            move |_| allow_additional_audiences
+        });
+
+        let claims = match id_token.claims(&verifier, &nonce) {
             Ok(claims) => claims.clone(),
             // A signature failure typically means the provider rotated its
             // signing keys since discovery, so the JWKS cached at startup is
@@ -316,10 +323,19 @@ impl OAuth2Handler {
                     "ID token signature verification failed; refreshing OIDC JWKS and retrying (provider may have rotated signing keys)"
                 );
                 let refreshed = self.rediscover().await?;
-                let claims = id_token
-                    .claims(&refreshed.id_token_verifier(), &nonce)
-                    .map_err(|e| OAuth2Error::TokenVerificationError(e.to_string()))?
-                    .clone();
+                let claims = {
+                    let verifier = refreshed
+                        .id_token_verifier()
+                        .set_other_audience_verifier_fn({
+                            let allow_additional_audiences =
+                                self.settings.allow_additional_audiences;
+                            move |_| allow_additional_audiences
+                        });
+                    id_token
+                        .claims(&verifier, &nonce)
+                        .map_err(|e| OAuth2Error::TokenVerificationError(e.to_string()))?
+                        .clone()
+                };
                 // Persist the refreshed client so subsequent logins reuse the
                 // new keys instead of re-fetching on every request.
                 *self.client.lock().expect("OAuth2 client mutex poisoned") = refreshed;
@@ -852,6 +868,7 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
 -----END RSA PRIVATE KEY-----";
 
     const CLIENT_ID: &str = "test-client";
+    const OTHER_AUDIENCE: &str = "other-audience";
     const SUBJECT: &str = "user-subject-123";
     const NONCE: &str = "test-nonce";
 
@@ -865,6 +882,8 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
         /// Number of times the JWKS endpoint was fetched, i.e. how often the
         /// handler ran discovery.
         jwks_fetches: AtomicUsize,
+        /// Whether the mock token includes the configured client ID in `aud`.
+        include_client_audience: AtomicBool,
     }
 
     impl MockProvider {
@@ -878,9 +897,18 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
 
         /// Mint an ID token signed with the currently active key.
         fn sign_id_token(&self) -> String {
+            let audiences = if self.include_client_audience.load(Ordering::SeqCst) {
+                vec![
+                    Audience::new(OTHER_AUDIENCE.to_string()),
+                    Audience::new(CLIENT_ID.to_string()),
+                ]
+            } else {
+                vec![Audience::new(OTHER_AUDIENCE.to_string())]
+            };
+
             let claims = CoreIdTokenClaims::new(
                 IssuerUrl::new(self.issuer.clone()).unwrap(),
-                vec![Audience::new(CLIENT_ID.to_string())],
+                audiences,
                 Utc::now() + Duration::minutes(5),
                 Utc::now(),
                 StandardClaims::new(SubjectIdentifier::new(SUBJECT.to_string()))
@@ -933,12 +961,13 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
         }))
     }
 
-    fn test_settings(issuer: &str) -> OAuth2Settings {
+    fn test_settings(issuer: &str, allow_additional_audiences: bool) -> OAuth2Settings {
         OAuth2Settings {
             enabled: true,
             issuer_url: Some(issuer.to_string()),
             client_id: Some(CLIENT_ID.to_string()),
             client_secret: Some("test-secret".to_string()),
+            allow_additional_audiences,
             ..Default::default()
         }
     }
@@ -964,6 +993,7 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
             .unwrap(),
             rotated: AtomicBool::new(false),
             jwks_fetches: AtomicUsize::new(0),
+            include_client_audience: AtomicBool::new(true),
         });
 
         let app = Router::new()
@@ -978,9 +1008,10 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
         });
 
         // Discovery caches key A (first JWKS fetch).
-        let handler = OAuth2Handler::from_discovery(&test_settings(&issuer), "http://localhost/cb")
-            .await
-            .expect("discovery should succeed");
+        let handler =
+            OAuth2Handler::from_discovery(&test_settings(&issuer, true), "http://localhost/cb")
+                .await
+                .expect("discovery should succeed");
         assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 1);
 
         // Baseline: a token signed with key A verifies against the cached JWKS
@@ -1013,6 +1044,34 @@ Y4dOyrc/PytM2BLxs06WhIWeneUpz64RtUlvZUrSDgnO5AQX0ba2
             .expect("exchange should reuse the refreshed JWKS");
         assert_eq!(result.claims.subject().as_str(), SUBJECT);
         assert_eq!(provider.jwks_fetches.load(Ordering::SeqCst), 2);
+
+        // The client ID remains mandatory even when additional audiences are
+        // accepted.
+        provider
+            .include_client_audience
+            .store(false, Ordering::SeqCst);
+        assert!(
+            handler
+                .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+                .await
+                .is_err()
+        );
+
+        // Strict mode rejects an otherwise valid token when it contains an
+        // audience other than the configured client ID.
+        provider
+            .include_client_audience
+            .store(true, Ordering::SeqCst);
+        let strict_handler =
+            OAuth2Handler::from_discovery(&test_settings(&issuer, false), "http://localhost/cb")
+                .await
+                .expect("strict discovery should succeed");
+        assert!(
+            strict_handler
+                .exchange_and_validate("auth-code", "pkce-verifier", NONCE)
+                .await
+                .is_err()
+        );
 
         server.abort();
     }

--- a/crates/settings/src/oauth2.rs
+++ b/crates/settings/src/oauth2.rs
@@ -32,8 +32,10 @@ pub struct OAuth2 {
     #[configurable(secret)]
     pub client_secret: Option<String>,
 
-    /// Accept additional audiences in the ID token when the client ID is present
-    pub allow_additional_audiences: bool,
+    /// Additional audiences accepted in the ID token besides the client ID
+    #[configurable(env_list)]
+    #[arg(value_delimiter = ',')]
+    pub additional_audiences: Vec<String>,
 
     /// `OAuth2` scopes to request (default: `["openid", "profile", "email"]`)
     #[configurable(env_list)]
@@ -66,7 +68,7 @@ impl Default for OAuth2 {
             issuer_url: None,
             client_id: None,
             client_secret: None,
-            allow_additional_audiences: false,
+            additional_audiences: Vec::new(),
             scopes: default_scopes(),
             auto_provision_users: true,
             admin_group_claim: None,
@@ -125,7 +127,7 @@ mod tests {
         assert!(oauth2.issuer_url.is_none());
         assert!(oauth2.client_id.is_none());
         assert!(oauth2.client_secret.is_none());
-        assert!(!oauth2.allow_additional_audiences);
+        assert!(oauth2.additional_audiences.is_empty());
         assert_eq!(oauth2.scopes, vec!["openid", "profile", "email"]);
         assert!(oauth2.auto_provision_users);
         assert_eq!(oauth2.button_text, "Login with SSO");

--- a/crates/settings/src/oauth2.rs
+++ b/crates/settings/src/oauth2.rs
@@ -32,6 +32,9 @@ pub struct OAuth2 {
     #[configurable(secret)]
     pub client_secret: Option<String>,
 
+    /// Accept additional audiences in the ID token when the client ID is present
+    pub allow_additional_audiences: bool,
+
     /// `OAuth2` scopes to request (default: `["openid", "profile", "email"]`)
     #[configurable(env_list)]
     #[arg(value_delimiter = ',')]
@@ -63,6 +66,7 @@ impl Default for OAuth2 {
             issuer_url: None,
             client_id: None,
             client_secret: None,
+            allow_additional_audiences: false,
             scopes: default_scopes(),
             auto_provision_users: true,
             admin_group_claim: None,
@@ -121,6 +125,7 @@ mod tests {
         assert!(oauth2.issuer_url.is_none());
         assert!(oauth2.client_id.is_none());
         assert!(oauth2.client_secret.is_none());
+        assert!(!oauth2.allow_additional_audiences);
         assert_eq!(oauth2.scopes, vec!["openid", "profile", "email"]);
         assert!(oauth2.auto_provision_users);
         assert_eq!(oauth2.button_text, "Login with SSO");

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -82,7 +82,11 @@ pub fn build_prov_with_cli(
 /// Matches the kellnr 6.x behaviour driven by the `config` crate's
 /// `with_list_parse_key`.
 pub(crate) fn env_list_keys() -> &'static [&'static str] {
-    &["registry.required_crate_fields", "oauth2.scopes"]
+    &[
+        "registry.required_crate_fields",
+        "oauth2.scopes",
+        "oauth2.additional_audiences",
+    ]
 }
 
 /// Convert provcfg's per-leaf provenance map into kellnr's `SourceMap`.


### PR DESCRIPTION
Hey, while trying out kellnr with my IdP (Zitadel) I saw it sending multiple aud in the token during oauth2 and kellnr right now need the aud to only have the clientId in aud.

With the related PR for the helm chart and this PR, it allows it to accept "extra" aud.

kellnr helm PR : https://github.com/kellnr/helm/pull/93