### PR TITLE
fix(index): keep rust_version in served crates.io index entries

### DIFF
--- a/crates/common/src/index_metadata.rs
+++ b/crates/common/src/index_metadata.rs
@@ -120,6 +120,13 @@ pub struct IndexMetadata {
     // }
     #[serde(skip_serializing_if = "Option::is_none")]
     pub features2: Option<BTreeMap<String, Vec<String>>>,
+    // The minimal supported Rust version of the package, or null if not
+    // specified. This field is optional and defaults to null.
+    //
+    // Note that the index spells this field `rust_version`, while the
+    // manifest key it originates from is `rust-version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rust_version: Option<String>,
 }
 
 impl IndexMetadata {
@@ -197,6 +204,7 @@ impl IndexMetadata {
             links: registry_metadata.links.clone(),
             v: Some(1),
             features2: None,
+            rust_version: registry_metadata.rust_version.clone(),
         }
     }
 
@@ -212,6 +220,7 @@ impl IndexMetadata {
             pubtime: None,
             v: Some(1),
             features2: None,
+            rust_version: None,
         }
     }
 
@@ -475,6 +484,7 @@ mod tests {
             pubtime: Some(pubtime),
             v: Some(1),
             features2: None,
+            rust_version: None,
         };
 
         let json = metadata.to_json().unwrap();
@@ -499,6 +509,7 @@ mod tests {
             pubtime: None,
             v: Some(1),
             features2: None,
+            rust_version: None,
         };
 
         let json = metadata.to_json().unwrap();
@@ -547,6 +558,33 @@ mod tests {
     }
 
     #[test]
+    fn rust_version_round_trips_losslessly() {
+        // The index spells the MSRV field `rust_version`, unlike the
+        // `rust-version` manifest key it is derived from.
+        let json = r#"{"name":"anyhow","vers":"1.0.100","deps":[],"cksum":"abc","features":{},"yanked":false,"v":2,"rust_version":"1.39"}"#;
+
+        let metadata: IndexMetadata = serde_json::from_str(json).unwrap();
+
+        assert_eq!(metadata.rust_version, Some("1.39".to_string()));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&metadata.to_json().unwrap()).unwrap(),
+            serde_json::from_str::<serde_json::Value>(json).unwrap()
+        );
+    }
+
+    #[test]
+    fn rust_version_none_is_omitted_from_serialization() {
+        let metadata = IndexMetadata::minimal("test", "1.0.0", "abc123");
+
+        let json = metadata.to_json().unwrap();
+
+        assert!(
+            !json.contains("rust_version"),
+            "Expected rust_version to be omitted when None, got: {json}"
+        );
+    }
+
+    #[test]
     fn serialize_indices_ends_with_newline_and_one_line_per_entry() {
         let mk = |vers: &str| IndexMetadata {
             name: "crate".to_string(),
@@ -559,6 +597,7 @@ mod tests {
             pubtime: None,
             v: Some(1),
             features2: None,
+            rust_version: None,
         };
         let indices = vec![mk("1.0.0"), mk("2.0.0")];
 

--- a/crates/db/entity/src/crate_index.rs
+++ b/crates/db/entity/src/crate_index.rs
@@ -23,6 +23,8 @@ pub struct Model {
     pub v: i32,
     pub crate_fk: i64,
     pub pubtime: Option<DateTime>,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub rust_version: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/db/entity/src/cratesio_index.rs
+++ b/crates/db/entity/src/cratesio_index.rs
@@ -25,6 +25,8 @@ pub struct Model {
     pub v: i32,
     pub crates_io_fk: i64,
     pub pubtime: Option<DateTime>,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub rust_version: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/db/migration/src/iden.rs
+++ b/crates/db/migration/src/iden.rs
@@ -163,6 +163,7 @@ pub enum CrateIndexIden {
     Links,
     V,
     CrateFk,
+    RustVersion,
 }
 
 #[derive(Iden, Copy, Clone)]
@@ -192,6 +193,7 @@ pub enum CratesIoIndexIden {
     Links,
     V,
     CratesIoFk,
+    RustVersion,
 }
 
 #[derive(Iden, Copy, Clone)]

--- a/crates/db/migration/src/lib.rs
+++ b/crates/db/migration/src/lib.rs
@@ -6,6 +6,7 @@ mod m20260128_000001_oauth2_identity;
 mod m20260129_000001_database_improvements;
 mod m20260130_000001_toolchain;
 mod m20260406_000001_toolchain_component;
+mod m20260903_000001_index_rust_version;
 
 pub struct Migrator;
 
@@ -19,6 +20,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260129_000001_database_improvements::Migration),
             Box::new(m20260130_000001_toolchain::Migration),
             Box::new(m20260406_000001_toolchain_component::Migration),
+            Box::new(m20260903_000001_index_rust_version::Migration),
         ]
     }
 }

--- a/crates/db/migration/src/m20260903_000001_index_rust_version.rs
+++ b/crates/db/migration/src/m20260903_000001_index_rust_version.rs
@@ -1,0 +1,56 @@
+use sea_orm_migration::prelude::*;
+
+use crate::iden::{CrateIndexIden, CratesIoIndexIden};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // The minimal supported Rust version is part of the sparse index
+        // format. Without it, cargo's MSRV-aware resolver cannot tell which
+        // versions the active toolchain is able to compile.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CrateIndexIden::Table)
+                    .add_column(ColumnDef::new(CrateIndexIden::RustVersion).text())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CratesIoIndexIden::Table)
+                    .add_column(ColumnDef::new(CratesIoIndexIden::RustVersion).text())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CratesIoIndexIden::Table)
+                    .drop_column(CratesIoIndexIden::RustVersion)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CrateIndexIden::Table)
+                    .drop_column(CrateIndexIden::RustVersion)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -1766,6 +1766,7 @@ impl DbProvider for Database {
                     pubtime: Set(index.pubtime.map(|dt| dt.naive_utc())),
                     v: Set(index.v.unwrap_or(1) as i32),
                     crates_io_fk: Set(krate.id),
+                    rust_version: Set(index.rust_version.clone()),
                 };
 
                 new_index.insert(&txn).await?;

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -1731,11 +1731,25 @@ impl DbProvider for Database {
             .await?;
 
         for index in indices {
-            // Check if the version was yanked or un-yanked and update if so.
+            // Refresh the mutable parts of an already cached version. "yanked"
+            // can flip upstream at any time. "rust_version" is refreshed too
+            // because caches written before the column existed hold NULL for
+            // every row, and only a refresh can heal them.
             if let Some(current_index) = current_indices.iter().find(|ci| index.vers == ci.vers) {
+                let mut ci: cratesio_index::ActiveModel = current_index.to_owned().into();
+                let mut changed = false;
+
                 if index.yanked != current_index.yanked {
-                    let mut ci: cratesio_index::ActiveModel = current_index.to_owned().into();
                     ci.yanked = Set(index.yanked);
+                    changed = true;
+                }
+
+                if index.rust_version != current_index.rust_version {
+                    ci.rust_version = Set(index.rust_version.clone());
+                    changed = true;
+                }
+
+                if changed {
                     ci.update(&txn).await?;
                 }
             } else {

--- a/crates/db/src/database/operations.rs
+++ b/crates/db/src/database/operations.rs
@@ -162,6 +162,7 @@ pub async fn add_crate_index<C: ConnectionTrait>(
         links: Set(index_data.links),
         v: Set(index_data.v.unwrap_or(1) as i32),
         crate_fk: Set(crate_id),
+        rust_version: Set(index_data.rust_version),
     };
 
     ci.insert(db_con).await?;
@@ -380,6 +381,7 @@ pub fn crate_index_model_to_index_metadata(
             links: ci.links,
             v: Some(ci.v as u32),
             features2: None,
+            rust_version: ci.rust_version,
         };
         index_metadata.push(cm);
     }
@@ -425,6 +427,7 @@ pub fn cratesio_index_model_to_index_metadata(
             yanked: ci.yanked,
             links: ci.links.clone(),
             v: Some(ci.v as u32),
+            rust_version: ci.rust_version.clone(),
         };
         index_metadata.push(cm);
     }

--- a/crates/db/src/database/test_utils.rs
+++ b/crates/db/src/database/test_utils.rs
@@ -246,6 +246,7 @@ pub async fn test_add_cached_crate(db: &Database, name: &str, version: &str) -> 
         yanked: false,
         links: None,
         v: Some(1),
+        rust_version: None,
     }];
 
     db.add_cratesio_prefetch_data(

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -2971,3 +2971,52 @@ async fn crate_index_keeps_rust_version(test_db: &kellnr_db::Database) {
 
     assert_eq!(Some("1.85".to_string()), index.rust_version);
 }
+
+#[db_test]
+async fn cratesio_index_heals_missing_rust_version(test_db: &kellnr_db::Database) {
+    let mut index = IndexMetadata {
+        name: "crate".to_string(),
+        vers: "1.0.0".to_string(),
+        deps: vec![],
+        cksum: "cksum".to_string(),
+        features: BTreeMap::default(),
+        yanked: false,
+        links: None,
+        pubtime: None,
+        v: Some(2),
+        features2: None,
+        rust_version: None,
+    };
+    let name = OriginalName::from_unchecked("crate".to_string());
+
+    // A cache written before rust_version was known, e.g. by an older Kellnr.
+    test_db
+        .add_cratesio_prefetch_data(&name, "etag", "last_modified", None, &[index.clone()])
+        .await
+        .unwrap();
+
+    // The same version comes back from the background refresh, now with an
+    // MSRV. The row already exists, so only an update can heal it.
+    index.rust_version = Some("1.85".to_string());
+    test_db
+        .add_cratesio_prefetch_data(&name, "new_etag", "last_modified", None, &[index])
+        .await
+        .unwrap();
+
+    let prefetch_state = test_db
+        .is_cratesio_cache_up_to_date(
+            &NormalizedName::from(OriginalName::try_from("crate").unwrap()),
+            Some("old_etag".to_string()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let PrefetchState::NeedsUpdate(prefetch) = prefetch_state else {
+        panic!("Expected the cratesio cache to need an update: {prefetch_state:?}");
+    };
+    let data = String::from_utf8(prefetch.data).unwrap();
+    let served: IndexMetadata = serde_json::from_str(data.lines().next().unwrap()).unwrap();
+
+    assert_eq!(Some("1.85".to_string()), served.rust_version);
+}

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -2337,6 +2337,7 @@ async fn is_cratesio_cache_up_to_date_up_to_date(test_db: &kellnr_db::Database) 
                 pubtime: None,
                 v: Some(1),
                 features2: None,
+                rust_version: None,
             }],
         )
         .await
@@ -2367,6 +2368,7 @@ async fn is_cratesio_cache_up_to_date_needs_update(test_db: &kellnr_db::Database
         pubtime: None,
         v: Some(1),
         features2: None,
+        rust_version: None,
     }];
     test_db
         .add_cratesio_prefetch_data(
@@ -2390,6 +2392,7 @@ async fn is_cratesio_cache_up_to_date_needs_update(test_db: &kellnr_db::Database
             pubtime: None,
             v: Some(1),
             features2: None,
+            rust_version: None,
         },
         IndexMetadata {
             name: "crate".to_string(),
@@ -2402,6 +2405,7 @@ async fn is_cratesio_cache_up_to_date_needs_update(test_db: &kellnr_db::Database
             pubtime: None,
             v: Some(1),
             features2: None,
+            rust_version: None,
         },
     ];
     test_db
@@ -2903,4 +2907,67 @@ async fn pubtime_stored_and_serialized_correctly(test_db: &kellnr_db::Database) 
         json_str.contains(&format!(r#""pubtime":"{formatted}""#)),
         "Expected pubtime '{formatted}' in JSON: {json_str}"
     );
+}
+
+#[db_test]
+async fn cratesio_index_keeps_rust_version(test_db: &kellnr_db::Database) {
+    let indices = vec![IndexMetadata {
+        name: "crate".to_string(),
+        vers: "1.0.0".to_string(),
+        deps: vec![],
+        cksum: "cksum".to_string(),
+        features: BTreeMap::default(),
+        yanked: false,
+        links: None,
+        pubtime: None,
+        v: Some(2),
+        features2: None,
+        rust_version: Some("1.85".to_string()),
+    }];
+    test_db
+        .add_cratesio_prefetch_data(
+            &OriginalName::from_unchecked("crate".to_string()),
+            "etag",
+            "last_modified",
+            None,
+            &indices,
+        )
+        .await
+        .unwrap();
+
+    // An outdated etag forces the index to be rebuilt from the database
+    // instead of being echoed back from the data passed in above.
+    let prefetch_state = test_db
+        .is_cratesio_cache_up_to_date(
+            &NormalizedName::from(OriginalName::try_from("crate").unwrap()),
+            Some("old_etag".to_string()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let PrefetchState::NeedsUpdate(prefetch) = prefetch_state else {
+        panic!("Expected the cratesio cache to need an update: {prefetch_state:?}");
+    };
+    let data = String::from_utf8(prefetch.data).unwrap();
+    let index: IndexMetadata = serde_json::from_str(data.lines().next().unwrap()).unwrap();
+
+    assert_eq!(Some("1.85".to_string()), index.rust_version);
+}
+
+#[db_test]
+async fn crate_index_keeps_rust_version(test_db: &kellnr_db::Database) {
+    let created = Utc.with_ymd_and_hms(2020, 10, 7, 13, 18, 00).unwrap();
+    let mut pm = PublishMetadata::minimal("crate", "1.0.0");
+    pm.rust_version = Some("1.85".to_string());
+    test_db
+        .add_crate(&pm, "cksum", &created, "admin")
+        .await
+        .unwrap();
+
+    let prefetch = test_db.get_prefetch_data("crate").await.unwrap();
+    let data = String::from_utf8(prefetch.data).unwrap();
+    let index: IndexMetadata = serde_json::from_str(data.lines().next().unwrap()).unwrap();
+
+    assert_eq!(Some("1.85".to_string()), index.rust_version);
 }


### PR DESCRIPTION
Fixes #1362.

The crates.io proxy drops `rust_version` from the sparse index entries it serves, so cargo's MSRV-aware resolver (the default for edition 2024 / `resolver = "3"`) sees no minimum supported Rust version for any proxied crate and can select releases the active toolchain cannot compile. Every integrity check still passes — checksums, `yanked`, the full version set — which makes it easy to miss; the symptom appears later as a compile error in a transitive dependency the user never chose.

Proxied lines are not relayed verbatim: they are deserialized into `IndexMetadata`, persisted, and re-serialized from database columns. `IndexMetadata` had no `rust_version` field, so the value was discarded on the way in.

### Changes

1. **`fix(index): keep rust_version in served index entries`** — adds `rust_version: Option<String>` to `IndexMetadata` (`#[serde(default, skip_serializing_if = "Option::is_none")]`; the index spells it `rust_version`, unlike the `rust-version` manifest key), a nullable TEXT column on `crate_index` and `cratesio_index` via migration `m20260903_000001_index_rust_version`, and wiring on the read and write paths. Kellnr's own publish path is covered too — the value comes from `PublishMetadata`, which already carried it since #771.
2. **`fix(index): refresh rust_version on already-cached versions`** — `add_cratesio_prefetch_data` previously refreshed only `yanked` for a version it already had, so after upgrading, existing cache rows would keep a NULL MSRV forever. The existing-row branch now also refreshes `rust_version`.

Structured after #970, which added the `pubtime` index field; the migration uses the `iden.rs` enums like the most recent migrations rather than the older snapshot-entities style.

### Verification

Measured against `index.crates.io` with a local 6.8.0 instance, before and after. Version sets and `cksum`/`yanked` match in every case; only the MSRV column changes:

| crate | versions | `rust_version` upstream | before | after |
| --- | --- | --- | --- | --- |
| anyhow | 106 | 60 | 0 | 60 |
| clap | 461 | 197 | 0 | 197 |
| serde | 316 | 100 | 0 | 100 |
| tokio | 195 | 96 | 0 | 96 |
| regex | 169 | 30 | 0 | 30 |
| reqwest | 125 | 47 | 0 | 47 |
| serde_json | 183 | 83 | 0 | 83 |
| clap_builder | 108 | 108 | 0 | 108 |

Tests added: `rust_version_round_trips_losslessly` and `rust_version_none_is_omitted_from_serialization` (`kellnr-common`); `cratesio_index_keeps_rust_version`, `crate_index_keeps_rust_version` and `cratesio_index_heals_missing_rust_version` (`kellnr-db`). `cargo fmt --all -- --check` and `cargo check --workspace --all-targets` are clean; `cargo test -p kellnr-db` sqlite suite is 81/81. The `postgres_*` variants could not run here (testcontainers wants a Docker socket; this box has podman) — that applies to the existing postgres tests too. The migration is plain `ALTER TABLE ... ADD COLUMN <nullable text>`, portable across both backends.

### Upgrade behaviour, worth a maintainer's opinion

An existing cache heals only when crates.io answers a refresh with 200. The background update sends the stored ETag, so unchanged crates get a 304 and `add_cratesio_prefetch_data` is never reached — in practice a crate backfills the first time a new version is published upstream after the upgrade. Busy crates recover within hours; dormant ones may not. Verified: over a 617-row cache built by unpatched 6.8.0, anyhow went 0/106 → 60/106 once a 200 was forced, while serde and tokio stayed at 0 behind their 304s. Operators wanting an immediate full backfill can blank `cratesio_crate.e_tag`/`last_modified` and restart (~15s for anyhow here).

Happy to add a one-shot backfill to the migration, or an "ignore stored validators once after upgrade" path, if you would prefer the upgrade to be self-healing — I left it out to keep this change small.

Related, **not changed here**: on the crates.io side `deps`, `features`, `features2`, `links`, `cksum`, `pubtime` and `v` are likewise insert-only, so a pre-existing cache cannot pick up upstream corrections to those either. Only `yanked` was ever refreshed. That looked like a wider pre-existing gap than this fix should take on — let me know if you would like it addressed here or in a follow-up.

---

*Disclosure: this change was produced with AI assistance (Claude Code). All measurements above are from real runs against crates.io and a local Kellnr instance, and a human reviewed the change before submission.*
