### PR TITLE
feat(docs): serve generated docs from the pluggable Storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,7 @@ dependencies = [
  "kellnr-storage",
  "kellnr-web-ui",
  "kellnr-webhooks",
+ "mime_guess",
  "mockall",
  "moka",
  "openssl",
@@ -4348,6 +4349,7 @@ name = "kellnr-docs"
 version = "6.8.0"
 dependencies = [
  "axum",
+ "bytes",
  "cargo",
  "flate2",
  "fs_extra",
@@ -4361,6 +4363,7 @@ dependencies = [
  "kellnr-registry",
  "kellnr-settings",
  "kellnr-storage",
+ "mockall",
  "serde",
  "serde_json",
  "tar",
@@ -4516,6 +4519,8 @@ version = "6.8.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "chrono",
+ "futures-util",
  "kellnr-common",
  "kellnr-fakegcs-testcontainer",
  "kellnr-rustfs-testcontainer",
@@ -4523,6 +4528,7 @@ dependencies = [
  "moka",
  "object_store",
  "sha256",
+ "tempfile",
  "testcontainers",
  "thiserror 2.0.20",
  "tokio",
@@ -4534,6 +4540,7 @@ version = "6.8.0"
 dependencies = [
  "axum",
  "axum-extra",
+ "bytes",
  "cookie",
  "flume",
  "http-body-util",
@@ -4550,6 +4557,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "tempfile",
  "time",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ cookie = { version = "0.18.1", features = ["private", "percent-encode"] }
 flate2 = "1.1.9"
 flume = "0.12.0"
 fs_extra = "1.3.0"
+futures-util = "0.3"
 http-body-util = "0.1.3"
 hyper = "1.10.1"
 include_dir = "0.7.4"

--- a/crates/appstate/src/lib.rs
+++ b/crates/appstate/src/lib.rs
@@ -10,6 +10,7 @@ use kellnr_db::download_counter::DownloadCounter;
 use kellnr_settings::{Settings, SettingsProv};
 use kellnr_storage::cached_crate_storage::DynStorage;
 use kellnr_storage::cratesio_crate_storage::CratesIoCrateStorage;
+use kellnr_storage::docs_storage::DocsStorage;
 use kellnr_storage::fs_storage::FSStorage;
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 use kellnr_storage::toolchain_storage::ToolchainStorage;
@@ -23,6 +24,7 @@ pub type SettingsState = axum::extract::State<Arc<Settings>>;
 pub type SettingsProvState = axum::extract::State<Arc<SettingsProv>>;
 pub type CrateStorageState = axum::extract::State<Arc<KellnrCrateStorage>>;
 pub type CrateIoStorageState = axum::extract::State<Arc<CratesIoCrateStorage>>;
+pub type DocsStorageState = axum::extract::State<Arc<DocsStorage>>;
 pub type SigningKeyState = axum::extract::State<Key>;
 pub type CratesIoPrefetchSenderState = axum::extract::State<Sender<CratesioPrefetchMsg>>;
 pub type TokenCacheState = axum::extract::State<Arc<TokenCacheManager>>;
@@ -41,6 +43,10 @@ pub struct AppStateData {
     pub settings_prov: Arc<SettingsProv>,
     pub crate_storage: Arc<KellnrCrateStorage>,
     pub cratesio_storage: Arc<CratesIoCrateStorage>,
+    /// Always present, unlike `toolchain_storage`: `/docs/*` serving and
+    /// manual doc publishing are mounted regardless of `settings.docs.enabled`
+    /// (that flag only gates the automatic generation queue).
+    pub docs_storage: Arc<DocsStorage>,
     pub cratesio_prefetch_sender: Sender<CratesioPrefetchMsg>,
     pub token_cache: Arc<TokenCacheManager>,
     pub toolchain_storage: Option<Arc<ToolchainStorage>>,
@@ -71,6 +77,9 @@ pub fn test_state() -> AppStateData {
         &settings,
         Box::new(FSStorage::new(&settings.crates_io_path()).unwrap()) as DynStorage,
     ));
+    let docs_storage = Arc::new(DocsStorage::new(Box::new(
+        FSStorage::new(&settings.docs_path()).unwrap(),
+    ) as DynStorage));
     let (cratesio_prefetch_sender, _) = flume::unbounded();
     let token_cache = Arc::new(TokenCacheManager::new(false, 60, 1000));
     let download_counter = Arc::new(DownloadCounter::new(db.clone(), 30));
@@ -81,6 +90,7 @@ pub fn test_state() -> AppStateData {
         settings_prov,
         crate_storage,
         cratesio_storage,
+        docs_storage,
         cratesio_prefetch_sender,
         token_cache,
         toolchain_storage: None, // Toolchain storage disabled in tests by default

--- a/crates/docs/Cargo.toml
+++ b/crates/docs/Cargo.toml
@@ -22,6 +22,7 @@ kellnr-storage.workspace = true
 
 # External dependencies from crates.io
 axum.workspace = true
+bytes.workspace = true
 cargo.workspace = true
 utoipa.workspace = true
 flate2.workspace = true
@@ -31,6 +32,7 @@ hyper.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tar.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -38,7 +40,7 @@ zip.workspace = true
 
 [dev-dependencies]
 hyper.workspace = true
-tempfile.workspace = true
+mockall.workspace = true
 tokio.workspace = true
 tower.workspace = true
 

--- a/crates/docs/src/api.rs
+++ b/crates/docs/src/api.rs
@@ -1,7 +1,7 @@
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::response::Redirect;
-use kellnr_appstate::{AppState, DbState, SettingsState};
+use kellnr_appstate::{AppState, DbState, DocsStorageState, SettingsState};
 use kellnr_auth::token::Token;
 use kellnr_common::original_name::OriginalName;
 use kellnr_common::version::Version;
@@ -11,6 +11,7 @@ use kellnr_registry::kellnr_api::check_ownership;
 use crate::doc_archive::DocArchive;
 use crate::doc_queue_response::DocQueueResponse;
 use crate::docs_error::DocsError;
+use crate::upload::upload_dir_and_prune;
 use crate::upload_response::DocUploadResponse;
 use crate::{compute_doc_url, get_latest_version_with_doc};
 
@@ -49,10 +50,11 @@ pub async fn docs_in_queue(State(db): DbState) -> ApiResult<Json<DocQueueRespons
 pub async fn latest_docs(
     Path(package): Path<OriginalName>,
     State(settings): SettingsState,
+    State(docs_storage): DocsStorageState,
     State(db): DbState,
 ) -> Redirect {
     let name = package.to_normalized();
-    let opt_doc_version = get_latest_version_with_doc(&name, &settings);
+    let opt_doc_version = get_latest_version_with_doc(&name, &docs_storage).await;
     let res_db_version = db.get_max_version_from_name(&name).await;
 
     if let Some(doc_version) = opt_doc_version
@@ -94,6 +96,7 @@ pub async fn publish_docs(
 ) -> ApiResult<Json<DocUploadResponse>> {
     let db = state.db;
     let settings = state.settings;
+    let docs_storage = state.docs_storage;
     let normalized_name = package.to_normalized();
     let crate_version = &version.to_string();
 
@@ -111,11 +114,14 @@ pub async fn publish_docs(
     let user = kellnr_auth::maybe_user::MaybeUser::from_token(token);
     check_ownership(&normalized_name, &user, &db).await?;
 
-    let doc_path = settings.docs_path().join(&*package).join(crate_version);
+    let tmp_dir = tempfile::tempdir().map_err(DocsError::IoError)?;
+    let extract_path = tmp_dir.path().to_path_buf();
 
-    let _ = tokio::task::spawn_blocking(move || docs.extract(&doc_path))
+    tokio::task::spawn_blocking(move || docs.extract(&extract_path))
         .await
-        .map_err(|_| DocsError::ExtractFailed)?;
+        .map_err(|_| DocsError::ExtractFailed)??;
+
+    upload_dir_and_prune(tmp_dir.path(), "", &package, crate_version, &docs_storage).await?;
 
     db.update_docs_link(
         &normalized_name,
@@ -141,18 +147,24 @@ fn crate_does_not_exist(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
     use std::path::PathBuf;
     use std::sync::Arc;
 
     use axum::Router;
     use axum::body::Body;
-    use axum::http::Request;
-    use axum::routing::get;
+    use axum::http::{Request, StatusCode, header};
+    use axum::routing::{get, put};
     use http_body_util::BodyExt;
     use kellnr_appstate::AppStateData;
     use kellnr_common::normalized_name::NormalizedName;
+    use kellnr_db::User;
     use kellnr_db::mock::MockDb;
     use kellnr_db::{DbProvider, DocQueueEntry};
+    use kellnr_storage::cached_crate_storage::DynStorage;
+    use kellnr_storage::docs_storage::DocsStorage;
+    use kellnr_storage::fs_storage::FSStorage;
+    use mockall::predicate::eq;
     use tower::ServiceExt;
 
     use super::*;
@@ -210,5 +222,114 @@ mod tests {
                 db,
                 ..kellnr_appstate::test_state()
             })
+    }
+
+    fn build_zip(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let options = zip::write::SimpleFileOptions::default();
+        for (name, content) in files {
+            zip.start_file(*name, options).unwrap();
+            zip.write_all(content).unwrap();
+        }
+        zip.finish().unwrap();
+        buf
+    }
+
+    fn publish_app(db: Arc<dyn DbProvider>, docs_storage: Arc<DocsStorage>) -> Router {
+        Router::new()
+            .route("/{package}/{version}", put(publish_docs))
+            .with_state(AppStateData {
+                db,
+                docs_storage,
+                ..kellnr_appstate::test_state()
+            })
+    }
+
+    fn expect_admin_owner(db: &mut MockDb, normalized: &NormalizedName) {
+        db.expect_get_crate_id()
+            .with(eq(normalized.clone()))
+            .returning(|_| Ok(Some(1)));
+        db.expect_crate_version_exists()
+            .with(eq(1), eq("1.0.0"))
+            .returning(|_, _| Ok(true));
+        db.expect_get_user_from_token().returning(|_| {
+            Ok(User {
+                is_admin: true,
+                name: "admin".to_string(),
+                ..User::default()
+            })
+        });
+    }
+
+    #[tokio::test]
+    async fn publish_docs_uploads_files_and_updates_docs_link() {
+        let normalized = NormalizedName::from_unchecked("test-crate".to_string());
+        let mut db = MockDb::new();
+        expect_admin_owner(&mut db, &normalized);
+        db.expect_update_docs_link()
+            .with(
+                eq(normalized.clone()),
+                eq(Version::try_from("1.0.0").unwrap()),
+                eq("/docs/test-crate/1.0.0/doc/test_crate/index.html".to_string()),
+            )
+            .returning(|_, _, _| Ok(()));
+
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_storage = Arc::new(DocsStorage::new(Box::new(
+            FSStorage::new(tmp.path().to_str().unwrap()).unwrap(),
+        ) as DynStorage));
+
+        let kellnr = publish_app(Arc::new(db), docs_storage.clone());
+        let zip_bytes = build_zip(&[("doc/test_crate/index.html", b"<html>docs</html>")]);
+
+        let r = kellnr
+            .oneshot(
+                Request::put("/test-crate/1.0.0")
+                    .header(header::AUTHORIZATION, "sometoken")
+                    .body(Body::from(zip_bytes))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(r.status(), StatusCode::OK);
+
+        let key = DocsStorage::file_key("test-crate", "1.0.0", "doc/test_crate/index.html");
+        let stored = docs_storage.get(&key).await.unwrap();
+        assert_eq!(stored, bytes::Bytes::from_static(b"<html>docs</html>"));
+    }
+
+    #[tokio::test]
+    async fn publish_docs_propagates_extraction_failure() {
+        // A well-formed zip whose only entry escapes the extraction directory. The
+        // archive parses fine (`ZipArchive::new` succeeds) but `ZipArchive::extract`
+        // rejects the unsafe path, so the inner `Result` from `docs.extract(..)` must
+        // reach the caller as an error (previously silently discarded, returning 200).
+        let normalized = NormalizedName::from_unchecked("test-crate".to_string());
+        let mut db = MockDb::new();
+        expect_admin_owner(&mut db, &normalized);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let docs_storage = Arc::new(DocsStorage::new(Box::new(
+            FSStorage::new(tmp.path().to_str().unwrap()).unwrap(),
+        ) as DynStorage));
+
+        let kellnr = publish_app(Arc::new(db), docs_storage);
+        let zip_bytes = build_zip(&[("../escape.html", b"evil")]);
+
+        let r = kellnr
+            .oneshot(
+                Request::put("/test-crate/1.0.0")
+                    .header(header::AUTHORIZATION, "sometoken")
+                    .body(Body::from(zip_bytes))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Previously this error was silently discarded (`let _ = ...`), returning 200
+        // even though extraction failed. It must now surface as a client error.
+        assert_eq!(r.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/docs/src/doc_queue.rs
+++ b/crates/docs/src/doc_queue.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use cargo::GlobalContext;
@@ -7,22 +7,23 @@ use cargo::core::compiler::UserIntent;
 use cargo::core::resolver::CliFeatures;
 use cargo::ops::{self, CompileOptions, DocOptions, OutputFormat};
 use flate2::read::GzDecoder;
-use fs_extra::dir::{CopyOptions, copy};
 use kellnr_common::original_name::OriginalName;
 use kellnr_common::version::Version;
 use kellnr_db::{DbProvider, DocQueueEntry};
+use kellnr_storage::docs_storage::DocsStorage;
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 use tar::Archive;
-use tokio::fs::{create_dir_all, remove_dir_all};
+use tokio::fs::remove_dir_all;
 use tracing::error;
 
 use crate::compute_doc_url;
 use crate::docs_error::DocsError;
+use crate::upload::upload_dir_and_prune;
 
 pub fn doc_extraction_queue(
     db: Arc<dyn DbProvider>,
     cs: Arc<KellnrCrateStorage>,
-    docs_path: PathBuf,
+    docs_storage: Arc<DocsStorage>,
     path_prefix: String,
     cratesio_index: Option<String>,
 ) {
@@ -32,7 +33,7 @@ pub fn doc_extraction_queue(
             if let Err(e) = inner_loop(
                 db.clone(),
                 &cs,
-                &docs_path,
+                &docs_storage,
                 &path_prefix,
                 cratesio_index.as_deref(),
             )
@@ -47,14 +48,14 @@ pub fn doc_extraction_queue(
 async fn inner_loop(
     db: Arc<dyn DbProvider>,
     cs: &KellnrCrateStorage,
-    docs_path: &Path,
+    docs_storage: &DocsStorage,
     path_prefix: &str,
     cratesio_index: Option<&str>,
 ) -> Result<(), DocsError> {
     let entries = db.get_doc_queue().await?;
 
     for entry in entries {
-        if let Err(e) = extract_docs(&entry, cs, docs_path, cratesio_index).await {
+        if let Err(e) = extract_docs(&entry, cs, docs_storage, cratesio_index).await {
             error!("Failed to extract docs from crate: {e}");
         } else {
             if let Err(e) = clean_up(&entry.path).await {
@@ -75,7 +76,7 @@ async fn inner_loop(
 async fn extract_docs(
     doc: &DocQueueEntry,
     cs: &KellnrCrateStorage,
-    docs_path: &Path,
+    docs_storage: &DocsStorage,
     cratesio_index: Option<&str>,
 ) -> Result<(), DocsError> {
     // Unpack crate
@@ -98,12 +99,19 @@ async fn extract_docs(
     strip_rust_toolchain_files(generated_docs_path).await?;
     generate_docs(generated_docs_path, cratesio_index)?;
 
-    // Copy the docs directory
+    // Upload the docs directory, pruning any stale pages from a previous build.
+    // The `doc` key prefix mirrors the manual-upload path (api.rs), where the
+    // uploaded zip already contains a top-level `doc/` folder: both must land
+    // under `{crate}/{version}/doc/...` to match `compute_doc_url`.
     let from = generated_docs_path.join("target").join("doc");
-    let to = docs_path
-        .join(doc.normalized_name.to_string())
-        .join(&doc.version);
-    copy_dir(&from, &to).await?;
+    upload_dir_and_prune(
+        &from,
+        "doc",
+        &doc.normalized_name.to_string(),
+        &doc.version,
+        docs_storage,
+    )
+    .await?;
 
     Ok(())
 }
@@ -144,19 +152,6 @@ async fn strip_rust_toolchain_files(crate_path: &Path) -> Result<(), DocsError> 
             Err(e) => return Err(e.into()),
         }
     }
-    Ok(())
-}
-
-async fn copy_dir(from: &Path, to: &Path) -> Result<(), DocsError> {
-    create_dir_all(to).await?;
-    copy(
-        from,
-        to,
-        &CopyOptions {
-            overwrite: true,
-            ..CopyOptions::default()
-        },
-    )?;
     Ok(())
 }
 

--- a/crates/docs/src/docs_error.rs
+++ b/crates/docs/src/docs_error.rs
@@ -1,5 +1,6 @@
 use hyper::StatusCode;
 use kellnr_error::api_error::ApiError;
+use kellnr_storage::storage_error::StorageError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -12,10 +13,14 @@ pub enum DocsError {
     DatabaseError(#[from] kellnr_db::error::DbError),
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
-    #[error("Failed to copy directory: {0}")]
-    CopyError(#[from] fs_extra::error::Error),
+    #[error("Failed to walk docs directory: {0}")]
+    DirWalkError(#[from] fs_extra::error::Error),
     #[error("Cargo error: {0}")]
     CargoError(String),
+    #[error("Docs storage error: {0}")]
+    StorageError(#[from] StorageError),
+    #[error("Path {path} is not inside {root}")]
+    PathPrefixMismatch { path: String, root: String },
 }
 
 impl From<DocsError> for ApiError {
@@ -29,7 +34,7 @@ impl From<DocsError> for ApiError {
             DocsError::IoError(error) => {
                 ApiError::from_err(&error, StatusCode::INTERNAL_SERVER_ERROR)
             }
-            DocsError::CopyError(error) => {
+            DocsError::DirWalkError(error) => {
                 ApiError::from_err(&error, StatusCode::INTERNAL_SERVER_ERROR)
             }
             DocsError::CargoError(error) => ApiError::new(
@@ -37,6 +42,10 @@ impl From<DocsError> for ApiError {
                 &String::default(),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ),
+            DocsError::StorageError(error) => ApiError::from(error),
+            DocsError::PathPrefixMismatch { .. } => {
+                ApiError::from_err(&e, StatusCode::INTERNAL_SERVER_ERROR)
+            }
         }
     }
 }

--- a/crates/docs/src/lib.rs
+++ b/crates/docs/src/lib.rs
@@ -3,32 +3,33 @@ mod doc_archive;
 pub mod doc_queue;
 pub mod doc_queue_response;
 pub mod docs_error;
+pub mod upload;
 pub mod upload_response;
 
 use std::convert::TryFrom;
-use std::path::Path;
 
 use kellnr_common::version::Version;
-use kellnr_settings::Settings;
+use kellnr_storage::docs_storage::DocsStorage;
 
-pub fn get_latest_doc_url(crate_name: &str, settings: &Settings) -> Option<String> {
-    let version = get_latest_version_with_doc(crate_name, settings);
-    version.map(|v| compute_doc_url(crate_name, &v, &settings.origin.path))
-}
+use crate::docs_error::DocsError;
 
-pub fn get_doc_url(
+pub async fn get_latest_doc_url(
     crate_name: &str,
-    crate_version: &Version,
-    docs_path: &Path,
+    docs_storage: &DocsStorage,
     path_prefix: &str,
 ) -> Option<String> {
-    let docs_name = crate_name_to_docs_name(crate_name);
-    let path_prefix = path_prefix.trim();
+    let version = get_latest_version_with_doc(crate_name, docs_storage).await?;
+    Some(compute_doc_url(crate_name, &version, path_prefix))
+}
 
-    if doc_exists(crate_name, crate_version, docs_path) {
-        Some(format!(
-            "{path_prefix}/docs/{crate_name}/{crate_version}/doc/{docs_name}/index.html"
-        ))
+pub async fn get_doc_url(
+    crate_name: &str,
+    crate_version: &Version,
+    docs_storage: &DocsStorage,
+    path_prefix: &str,
+) -> Option<String> {
+    if doc_exists(crate_name, &crate_version.to_string(), docs_storage).await {
+        Some(compute_doc_url(crate_name, crate_version, path_prefix))
     } else {
         None
     }
@@ -46,62 +47,57 @@ fn crate_name_to_docs_name(crate_name: &str) -> String {
     crate_name.replace('-', "_")
 }
 
-fn doc_exists(crate_name: &str, crate_version: &str, docs_path: &Path) -> bool {
+async fn doc_exists(crate_name: &str, crate_version: &str, docs_storage: &DocsStorage) -> bool {
     let docs_name = crate_name_to_docs_name(crate_name);
-    docs_path
-        .join(crate_name)
-        .join(crate_version)
-        .join("doc")
-        .join(docs_name)
-        .join("index.html")
-        .exists()
+    let key = DocsStorage::file_key(
+        crate_name,
+        crate_version,
+        &format!("doc/{docs_name}/index.html"),
+    );
+    docs_storage.exists(&key).await.unwrap_or(false)
 }
 
-fn get_latest_version_with_doc(crate_name: &str, settings: &Settings) -> Option<Version> {
-    let versions_path = settings.docs_path().join(crate_name);
-    let Ok(version_folders) = std::fs::read_dir(versions_path) else {
-        return None;
-    };
-
-    let mut versions: Vec<Version> = version_folders
-        .flatten()
-        .filter(|entry| entry.path().is_dir())
-        .flat_map(|dir| Version::try_from(&dir.file_name().to_string_lossy().to_string()))
+async fn get_latest_version_with_doc(
+    crate_name: &str,
+    docs_storage: &DocsStorage,
+) -> Option<Version> {
+    let mut versions: Vec<Version> = docs_storage
+        .version_candidates(crate_name)
+        .await
+        .ok()?
+        .into_iter()
+        .flat_map(|v| Version::try_from(&v))
         .collect();
 
     // Sort and reverse the order such that the biggest version
     // for which docs exist will be returned.
     versions.sort();
     versions.reverse();
-    versions
-        .into_iter()
-        .find(|v| doc_exists(crate_name, &v.to_string(), &settings.docs_path()))
+
+    for version in versions {
+        if doc_exists(crate_name, &version.to_string(), docs_storage).await {
+            return Some(version);
+        }
+    }
+    None
 }
 
 pub async fn delete(
     crate_name: &str,
     crate_version: &str,
-    settings: &Settings,
-) -> Result<(), std::io::Error> {
-    // Delete the docs folder for the crate version.
-    let docs_path = settings.docs_path().join(crate_name).join(crate_version);
-    if docs_path.exists() {
-        tokio::fs::remove_dir_all(docs_path).await?;
-    }
-
-    // If it was the last version, delete the empty crate docs folder.
-    if get_latest_version_with_doc(crate_name, settings).is_none() {
-        let crate_path = settings.docs_path().join(crate_name);
-        if crate_path.exists() {
-            tokio::fs::remove_dir_all(crate_path).await?;
-        }
-    }
-
+    docs_storage: &DocsStorage,
+) -> Result<(), DocsError> {
+    docs_storage
+        .delete_prefix(&DocsStorage::version_prefix(crate_name, crate_version))
+        .await?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+    use kellnr_storage::fs_storage::FSStorage;
+
     use super::*;
 
     #[test]
@@ -133,5 +129,64 @@ mod tests {
             url,
             "/docs/foo-bar-baz/2.0.0-beta1/doc/foo_bar_baz/index.html"
         );
+    }
+
+    fn docs_storage() -> (tempfile::TempDir, DocsStorage) {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = FSStorage::new(dir.path().to_str().unwrap()).unwrap();
+        (dir, DocsStorage::new(Box::new(storage)))
+    }
+
+    #[tokio::test]
+    async fn doc_exists_true_when_index_html_present() {
+        let (_dir, docs) = docs_storage();
+        let key = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+        docs.put(&key, Bytes::from_static(b"x")).await.unwrap();
+
+        assert!(doc_exists("my-crate", "1.0.0", &docs).await);
+    }
+
+    #[tokio::test]
+    async fn doc_exists_false_when_missing() {
+        let (_dir, docs) = docs_storage();
+        assert!(!doc_exists("my-crate", "1.0.0", &docs).await);
+    }
+
+    #[tokio::test]
+    async fn get_latest_version_with_doc_returns_highest_version() {
+        let (_dir, docs) = docs_storage();
+        for v in ["1.0.0", "2.0.0", "1.5.0"] {
+            let key = DocsStorage::file_key("my-crate", v, "doc/my_crate/index.html");
+            docs.put(&key, Bytes::from_static(b"x")).await.unwrap();
+        }
+
+        let latest = get_latest_version_with_doc("my-crate", &docs)
+            .await
+            .unwrap();
+        assert_eq!(latest.to_string(), "2.0.0");
+    }
+
+    #[tokio::test]
+    async fn get_latest_version_with_doc_none_when_no_versions() {
+        let (_dir, docs) = docs_storage();
+        assert!(
+            get_latest_version_with_doc("my-crate", &docs)
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_removes_only_targeted_version() {
+        let (_dir, docs) = docs_storage();
+        let v1 = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+        let v2 = DocsStorage::file_key("my-crate", "2.0.0", "doc/my_crate/index.html");
+        docs.put(&v1, Bytes::from_static(b"a")).await.unwrap();
+        docs.put(&v2, Bytes::from_static(b"b")).await.unwrap();
+
+        delete("my-crate", "1.0.0", &docs).await.unwrap();
+
+        assert!(!docs.exists(&v1).await.unwrap());
+        assert!(docs.exists(&v2).await.unwrap());
     }
 }

--- a/crates/docs/src/upload.rs
+++ b/crates/docs/src/upload.rs
@@ -1,0 +1,179 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use bytes::Bytes;
+use kellnr_storage::docs_storage::DocsStorage;
+
+use crate::docs_error::DocsError;
+
+/// Upload every file under `local_root` to `docs_storage` under the
+/// `{crate_name}/{version}/{key_prefix}/` prefix, then delete any pre-existing
+/// key under `{crate_name}/{version}/` that wasn't just uploaded.
+///
+/// Upload-then-prune (not delete-then-upload) so a partial/failed upload
+/// never leaves a doc version with zero pages.
+///
+/// `key_prefix` lets the auto-generation queue (which walks `target/doc`
+/// directly) and the manual-upload path (whose zip already contains a
+/// top-level `doc/` folder) both land under `{crate}/{version}/doc/...`,
+/// matching the layout `compute_doc_url` expects. Pass `""` when `local_root`
+/// already contains the full relative structure.
+pub async fn upload_dir_and_prune(
+    local_root: &Path,
+    key_prefix: &str,
+    crate_name: &str,
+    version: &str,
+    docs_storage: &DocsStorage,
+) -> Result<(), DocsError> {
+    let content = fs_extra::dir::get_dir_content(local_root)?;
+    let mut uploaded_keys = HashSet::new();
+
+    for file in &content.files {
+        let file_path = Path::new(file);
+        let relative =
+            file_path
+                .strip_prefix(local_root)
+                .map_err(|_| DocsError::PathPrefixMismatch {
+                    path: file.clone(),
+                    root: local_root.display().to_string(),
+                })?;
+        let relative_key = relative.to_string_lossy().replace('\\', "/");
+        let relative_key = if key_prefix.is_empty() {
+            relative_key
+        } else {
+            format!("{key_prefix}/{relative_key}")
+        };
+        let key = DocsStorage::file_key(crate_name, version, &relative_key);
+
+        let data = tokio::fs::read(file_path).await?;
+        docs_storage.put(&key, Bytes::from(data)).await?;
+        uploaded_keys.insert(key);
+    }
+
+    let prefix = DocsStorage::version_prefix(crate_name, version);
+    for existing_key in docs_storage.list(&prefix).await? {
+        if !uploaded_keys.contains(&existing_key) {
+            docs_storage.delete(&existing_key).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use kellnr_storage::fs_storage::FSStorage;
+
+    use super::*;
+
+    fn docs_storage() -> (tempfile::TempDir, DocsStorage) {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = FSStorage::new(dir.path().to_str().unwrap()).unwrap();
+        (dir, DocsStorage::new(Box::new(storage)))
+    }
+
+    #[tokio::test]
+    async fn upload_preserves_directory_structure() {
+        let (_storage_dir, docs) = docs_storage();
+        let local = tempfile::tempdir().unwrap();
+        tokio::fs::write(local.path().join("index.html"), b"root")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(local.path().join("nested"))
+            .await
+            .unwrap();
+        tokio::fs::write(local.path().join("nested/page.html"), b"nested")
+            .await
+            .unwrap();
+
+        upload_dir_and_prune(local.path(), "", "my-crate", "1.0.0", &docs)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            docs.get(&DocsStorage::file_key("my-crate", "1.0.0", "index.html"))
+                .await
+                .unwrap(),
+            Bytes::from_static(b"root")
+        );
+        assert_eq!(
+            docs.get(&DocsStorage::file_key(
+                "my-crate",
+                "1.0.0",
+                "nested/page.html"
+            ))
+            .await
+            .unwrap(),
+            Bytes::from_static(b"nested")
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_prunes_stale_keys_from_previous_build() {
+        let (_storage_dir, docs) = docs_storage();
+        let stale_key = DocsStorage::file_key("my-crate", "1.0.0", "removed.html");
+        docs.put(&stale_key, Bytes::from_static(b"old"))
+            .await
+            .unwrap();
+
+        let local = tempfile::tempdir().unwrap();
+        tokio::fs::write(local.path().join("index.html"), b"new")
+            .await
+            .unwrap();
+
+        upload_dir_and_prune(local.path(), "", "my-crate", "1.0.0", &docs)
+            .await
+            .unwrap();
+
+        assert!(!docs.exists(&stale_key).await.unwrap());
+        assert!(
+            docs.exists(&DocsStorage::file_key("my-crate", "1.0.0", "index.html"))
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_leaves_other_versions_untouched() {
+        let (_storage_dir, docs) = docs_storage();
+        let other_version_key = DocsStorage::file_key("my-crate", "2.0.0", "index.html");
+        docs.put(&other_version_key, Bytes::from_static(b"kept"))
+            .await
+            .unwrap();
+
+        let local = tempfile::tempdir().unwrap();
+        tokio::fs::write(local.path().join("index.html"), b"new")
+            .await
+            .unwrap();
+
+        upload_dir_and_prune(local.path(), "", "my-crate", "1.0.0", &docs)
+            .await
+            .unwrap();
+
+        assert!(docs.exists(&other_version_key).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn upload_nests_files_under_key_prefix() {
+        let (_storage_dir, docs) = docs_storage();
+        let local = tempfile::tempdir().unwrap();
+        tokio::fs::write(local.path().join("index.html"), b"root")
+            .await
+            .unwrap();
+
+        upload_dir_and_prune(local.path(), "doc", "my-crate", "1.0.0", &docs)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            docs.get(&DocsStorage::file_key(
+                "my-crate",
+                "1.0.0",
+                "doc/index.html"
+            ))
+            .await
+            .unwrap(),
+            Bytes::from_static(b"root")
+        );
+    }
+}

--- a/crates/kellnr/Cargo.toml
+++ b/crates/kellnr/Cargo.toml
@@ -33,6 +33,7 @@ utoipa.workspace = true
 utoipa-axum.workspace = true
 utoipa-swagger-ui.workspace = true
 flume.workspace = true
+mime_guess.workspace = true
 serde.workspace = true
 moka.workspace = true
 openssl = { version = "0.10", optional = true } # Not needed directly but for cross-compilation with the vendored-openssl feature

--- a/crates/kellnr/src/main.rs
+++ b/crates/kellnr/src/main.rs
@@ -21,6 +21,7 @@ use kellnr_settings::{
 };
 use kellnr_storage::cached_crate_storage::DynStorage;
 use kellnr_storage::cratesio_crate_storage::CratesIoCrateStorage;
+use kellnr_storage::docs_storage::DocsStorage;
 use kellnr_storage::fs_storage::FSStorage;
 use kellnr_storage::gcs_storage::GCSStorage;
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
@@ -172,12 +173,17 @@ async fn run_server(resolved: ResolvedSettings) {
     );
 
     // Docs hosting
-    init_docs_hosting(&settings, crate_storage.clone(), db.clone()).await;
+    let docs_storage: Arc<DocsStorage> = init_docs_storage(&settings).into();
+    init_docs_hosting(
+        &settings,
+        crate_storage.clone(),
+        docs_storage.clone(),
+        db.clone(),
+    );
 
     // Webhook support
     init_webhook_service(db.clone());
 
-    let data_dir = settings.registry.data_dir.clone();
     let signing_key = init_cookie_signing_key(&settings);
     let max_docs_size = settings.docs.max_size;
     let max_crate_size = settings.registry.max_crate_size as usize;
@@ -251,6 +257,7 @@ async fn run_server(resolved: ResolvedSettings) {
         settings_prov,
         crate_storage,
         cratesio_storage,
+        docs_storage,
         cratesio_prefetch_sender,
         token_cache,
         toolchain_storage,
@@ -261,7 +268,6 @@ async fn run_server(resolved: ResolvedSettings) {
     // Create router using the route module
     let mut app = routes::create_router(
         state,
-        &data_dir,
         max_docs_size,
         max_crate_size,
         max_toolchain_size,
@@ -351,19 +357,17 @@ fn get_connect_string(settings: &Settings) -> ConString {
     }
 }
 
-async fn init_docs_hosting(
+fn init_docs_hosting(
     settings: &Settings,
     cs: Arc<KellnrCrateStorage>,
+    docs_storage: Arc<DocsStorage>,
     db: Arc<dyn DbProvider + 'static>,
 ) {
-    create_dir_all(settings.docs_path())
-        .await
-        .expect("Failed to create docs directory.");
     if settings.docs.enabled {
         kellnr_docs::doc_queue::doc_extraction_queue(
             db,
             cs,
-            settings.docs_path(),
+            docs_storage,
             settings.origin.path.clone(),
             settings
                 .proxy
@@ -371,6 +375,26 @@ async fn init_docs_hosting(
                 .map(ToString::to_string),
         );
     }
+}
+
+fn init_docs_storage(settings: &Settings) -> DocsStorage {
+    let storage: DynStorage = if settings.s3.enabled
+        && let Some(bucket) = &settings.s3.docs_bucket
+    {
+        Box::new(
+            S3Storage::try_from((bucket.as_str(), settings)).expect("Failed to create S3 storage."),
+        )
+    } else if settings.gcs.enabled
+        && let Some(bucket) = &settings.gcs.docs_bucket
+    {
+        Box::new(
+            GCSStorage::try_from((bucket.as_str(), settings))
+                .expect("Failed to create GCS storage."),
+        )
+    } else {
+        Box::new(FSStorage::new(&settings.docs_path()).expect("Failed to create FS storage."))
+    };
+    DocsStorage::new(storage)
 }
 
 fn init_cratesio_storage(settings: &Settings) -> CratesIoCrateStorage {
@@ -442,5 +466,32 @@ async fn init_oauth2_handler(settings: &Settings) -> Option<Arc<OAuth2Handler>> 
             warn!("OAuth2/OIDC authentication will be disabled");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use kellnr_settings::test_settings;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn init_docs_storage_falls_back_to_local_disk_when_bucket_unset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut settings = test_settings();
+        settings.registry.data_dir = tmp.path().to_str().unwrap().to_string();
+        settings.s3.enabled = true;
+        settings.s3.docs_bucket = None;
+
+        let docs_storage = init_docs_storage(&settings);
+        let key = DocsStorage::file_key("my-crate", "1.0.0", "doc/index.html");
+        docs_storage
+            .put(&key, Bytes::from_static(b"hi"))
+            .await
+            .unwrap();
+
+        let expected_path = Path::new(&settings.docs_path()).join("my-crate/1.0.0/doc/index.html");
+        assert!(expected_path.exists());
     }
 }

--- a/crates/kellnr/src/routes/docs_routes.rs
+++ b/crates/kellnr/src/routes/docs_routes.rs
@@ -11,6 +11,7 @@ use utoipa_axum::routes;
 pub fn create_ui_routes(state: AppStateData) -> OpenApiRouter<AppStateData> {
     OpenApiRouter::new()
         .routes(routes!(api::docs_in_queue, ui::build_rustdoc))
+        .routes(routes!(ui::migrate_docs_storage))
         .routes(routes!(api::latest_docs))
         .layer(middleware::from_fn_with_state(
             state,

--- a/crates/kellnr/src/routes/docs_static.rs
+++ b/crates/kellnr/src/routes/docs_static.rs
@@ -1,0 +1,58 @@
+use std::time::SystemTime;
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum_extra::TypedHeader;
+use axum_extra::headers::{ETag, HeaderMapExt, IfModifiedSince, IfNoneMatch, LastModified};
+use kellnr_appstate::DocsStorageState;
+
+pub async fn serve_doc_file(
+    State(docs_storage): DocsStorageState,
+    Path(path): Path<String>,
+    if_none_match: Option<TypedHeader<IfNoneMatch>>,
+    if_modified_since: Option<TypedHeader<IfModifiedSince>>,
+) -> Response {
+    let Ok(object) = docs_storage.get_with_meta(&path).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let etag = object.e_tag.as_deref().and_then(|s| s.parse::<ETag>().ok());
+    let last_modified_time = SystemTime::from(object.last_modified);
+    let last_modified = LastModified::from(last_modified_time);
+
+    // If-None-Match takes precedence over If-Modified-Since when both are
+    // present, per RFC 9110 §13.1.2.
+    let not_modified =
+        if let (Some(TypedHeader(if_none_match)), Some(etag)) = (&if_none_match, &etag) {
+            !if_none_match.precondition_passes(etag)
+        } else if let Some(TypedHeader(if_modified_since)) = &if_modified_since {
+            !if_modified_since.is_modified(last_modified_time)
+        } else {
+            false
+        };
+
+    let mut response = if not_modified {
+        StatusCode::NOT_MODIFIED.into_response()
+    } else {
+        let mime = mime_guess::from_path(&path).first_or_octet_stream();
+        let mut response = (StatusCode::OK, object.bytes).into_response();
+        let headers = response.headers_mut();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_str(mime.as_ref())
+                .unwrap_or(HeaderValue::from_static("application/octet-stream")),
+        );
+        // Doc content can be overwritten by republishing, so always revalidate
+        // rather than letting clients cache without asking.
+        headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+        response
+    };
+
+    if let Some(etag) = etag {
+        response.headers_mut().typed_insert(etag);
+    }
+    response.headers_mut().typed_insert(last_modified);
+
+    response
+}

--- a/crates/kellnr/src/routes/mod.rs
+++ b/crates/kellnr/src/routes/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
-use axum::routing::{get, get_service};
+use axum::routing::get;
 use axum::{Extension, Router, middleware};
 use kellnr_appstate::AppStateData;
 use kellnr_auth::oauth2::OAuth2Handler;
@@ -12,7 +12,6 @@ use kellnr_embedded_resources::{embedded_static_handler, embedded_static_root_ha
 use kellnr_settings::Registry;
 use kellnr_web_ui::session;
 use tokio::sync::Semaphore;
-use tower_http::services::ServeDir;
 use tower_http::timeout::TimeoutLayer;
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
@@ -24,6 +23,7 @@ mod auth_routes;
 mod crate_access_routes;
 mod cratesio_api_routes;
 mod docs_routes;
+mod docs_static;
 mod group_routes;
 mod health_routes;
 mod kellnr_api_routes;
@@ -35,14 +35,14 @@ mod webhook_routes;
 
 pub fn create_router(
     state: AppStateData,
-    data_dir: &str,
     max_docs_size: usize,
     max_crate_size: usize,
     max_toolchain_size: usize,
     oauth2_handler: Option<Arc<OAuth2Handler>>,
 ) -> Router {
-    // Docs are served from disk and not from embedded assets
-    let docs_service = get_service(ServeDir::new(format!("{data_dir}/docs")))
+    // Docs are served from the pluggable Storage backend, not embedded assets.
+    let docs_service: Router<AppStateData> = Router::new()
+        .route("/{*path}", get(docs_static::serve_doc_file))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             session::session_auth_when_required,
@@ -105,7 +105,7 @@ pub fn create_router(
             "/api/v1/docs",
             docs_routes::create_manual_routes(max_docs_size),
         )
-        .nest_service("/docs", docs_service)
+        .nest("/docs", docs_service)
         // Serve Swagger UI at /api/docs with OpenAPI spec at /api/openapi.json
         .merge(SwaggerUi::new("/api/docs").url("/api/openapi.json", api));
 
@@ -211,4 +211,108 @@ pub(crate) fn apply_download_limits(
     }
 
     router
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode, header};
+    use bytes::Bytes;
+    use kellnr_storage::docs_storage::DocsStorage;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn docs_route_serves_stored_file_with_mime_and_csp() {
+        let state = kellnr_appstate::test_state();
+        let key = DocsStorage::file_key(
+            "routes-test-crate",
+            "1.0.0",
+            "doc/routes_test_crate/index.html",
+        );
+        state
+            .docs_storage
+            .put(&key, Bytes::from_static(b"<html>hi</html>"))
+            .await
+            .unwrap();
+
+        let app = create_router(state, 100, 100, 100, None);
+
+        let r = app
+            .oneshot(
+                Request::get(format!("/docs/{key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(r.status(), StatusCode::OK);
+        assert_eq!(r.headers().get(header::CONTENT_TYPE).unwrap(), "text/html");
+        assert!(r.headers().contains_key(header::CONTENT_SECURITY_POLICY));
+        assert!(r.headers().contains_key(header::ETAG));
+        assert!(r.headers().contains_key(header::LAST_MODIFIED));
+    }
+
+    #[tokio::test]
+    async fn docs_route_returns_304_for_matching_if_none_match() {
+        let state = kellnr_appstate::test_state();
+        let key = DocsStorage::file_key(
+            "routes-test-crate",
+            "1.0.0",
+            "doc/routes_test_crate/index.html",
+        );
+        state
+            .docs_storage
+            .put(&key, Bytes::from_static(b"<html>hi</html>"))
+            .await
+            .unwrap();
+
+        let app = create_router(state, 100, 100, 100, None);
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::get(format!("/docs/{key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let etag = first.headers().get(header::ETAG).unwrap().clone();
+
+        let second = app
+            .oneshot(
+                Request::get(format!("/docs/{key}"))
+                    .header(header::IF_NONE_MATCH, etag)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+        let body = axum::body::to_bytes(second.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn docs_route_404_for_missing_file() {
+        let state = kellnr_appstate::test_state();
+        let app = create_router(state, 100, 100, 100, None);
+
+        let r = app
+            .oneshot(
+                Request::get("/docs/routes-test-crate/does-not-exist/index.html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(r.status(), StatusCode::NOT_FOUND);
+    }
 }

--- a/crates/settings/src/gcs.rs
+++ b/crates/settings/src/gcs.rs
@@ -25,6 +25,8 @@ pub struct Gcs {
 
     pub toolchain_bucket: String,
 
+    pub docs_bucket: Option<String>,
+
     /// GCS connect timeout in seconds
     #[arg(long = "gcs-connect-timeout")]
     pub connect_timeout_seconds: u64,
@@ -44,6 +46,7 @@ impl Default for Gcs {
             crates_bucket: "kellnr-crates".to_string(),
             cratesio_bucket: "kellnr-cratesio".to_string(),
             toolchain_bucket: "kellnr-toolchains".to_string(),
+            docs_bucket: None,
             connect_timeout_seconds: 5,
             request_timeout_seconds: 30,
         }

--- a/crates/settings/src/s3.rs
+++ b/crates/settings/src/s3.rs
@@ -24,6 +24,8 @@ pub struct S3 {
 
     pub toolchain_bucket: String,
 
+    pub docs_bucket: Option<String>,
+
     /// S3 connect timeout in seconds
     #[arg(long = "s3-connect-timeout")]
     pub connect_timeout_seconds: u64,
@@ -45,6 +47,7 @@ impl Default for S3 {
             crates_bucket: "kellnr-crates".to_string(),
             cratesio_bucket: "kellnr-cratesio".to_string(),
             toolchain_bucket: "kellnr-toolchains".to_string(),
+            docs_bucket: None,
             connect_timeout_seconds: 5,
             request_timeout_seconds: 30,
         }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -111,8 +111,8 @@ impl Settings {
         PathBuf::from(&self.registry.data_dir).join("db.sqlite")
     }
 
-    pub fn docs_path(&self) -> PathBuf {
-        PathBuf::from(&self.registry.data_dir).join("docs")
+    pub fn docs_path(&self) -> String {
+        format!("{}/docs", self.registry.data_dir)
     }
 
     pub fn base_path(&self) -> PathBuf {
@@ -163,6 +163,15 @@ impl Settings {
         } else {
             self.toolchain_path()
         }
+    }
+
+    /// `false` once an operator has opted into `s3.docs_bucket`/`gcs.docs_bucket`
+    /// (see `init_docs_storage`) — unlike the other `*_path_or_bucket` methods,
+    /// docs stay on local disk by default even when `s3.enabled`/`gcs.enabled`
+    /// is set, so this can't be derived from `enabled` alone.
+    pub fn docs_backend_is_local(&self) -> bool {
+        !(self.s3.enabled && self.s3.docs_bucket.is_some()
+            || self.gcs.enabled && self.gcs.docs_bucket.is_some())
     }
 }
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -18,6 +18,8 @@ kellnr-settings.workspace = true
 # External dependencies
 async-trait.workspace = true
 bytes.workspace = true
+chrono.workspace = true
+futures-util.workspace = true
 moka.workspace = true
 object_store.workspace = true
 sha256.workspace = true
@@ -26,6 +28,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 kellnr-fakegcs-testcontainer.workspace = true
+tempfile.workspace = true
 testcontainers.workspace = true
 tokio.workspace = true
 

--- a/crates/storage/src/cached_crate_storage.rs
+++ b/crates/storage/src/cached_crate_storage.rs
@@ -120,6 +120,7 @@ mod tests {
     use async_trait::async_trait;
 
     use super::*;
+    use crate::storage::ObjectWithMeta;
 
     /// Shared state for tracking storage call counts.
     struct StorageMetrics {
@@ -158,7 +159,20 @@ mod tests {
                 .ok_or_else(|| StorageError::GenericError(format!("not found: {key}")))
         }
 
+        async fn get_with_meta(&self, key: &str) -> Result<ObjectWithMeta, StorageError> {
+            let bytes = self.get(key).await?;
+            Ok(ObjectWithMeta {
+                bytes,
+                e_tag: None,
+                last_modified: chrono::Utc::now(),
+            })
+        }
+
         async fn put(&self, _key: &str, _object: Bytes) -> Result<(), StorageError> {
+            Ok(())
+        }
+
+        async fn put_overwrite(&self, _key: &str, _object: Bytes) -> Result<(), StorageError> {
             Ok(())
         }
 
@@ -169,6 +183,15 @@ mod tests {
         async fn exists(&self, key: &str) -> Result<bool, StorageError> {
             Ok(self.data.contains_key(key))
         }
+
+        async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+            Ok(self
+                .data
+                .keys()
+                .filter(|k| k.starts_with(prefix))
+                .cloned()
+                .collect())
+        }
     }
 
     /// Wrapper to make `CountingStorage` usable through `Arc` (needed for concurrent test)
@@ -178,8 +201,16 @@ mod tests {
             (**self).get(key).await
         }
 
+        async fn get_with_meta(&self, key: &str) -> Result<ObjectWithMeta, StorageError> {
+            (**self).get_with_meta(key).await
+        }
+
         async fn put(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
             (**self).put(key, object).await
+        }
+
+        async fn put_overwrite(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
+            (**self).put_overwrite(key, object).await
         }
 
         async fn delete(&self, key: &str) -> Result<(), StorageError> {
@@ -188,6 +219,10 @@ mod tests {
 
         async fn exists(&self, key: &str) -> Result<bool, StorageError> {
             (**self).exists(key).await
+        }
+
+        async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+            (**self).list(prefix).await
         }
     }
 

--- a/crates/storage/src/docs_storage.rs
+++ b/crates/storage/src/docs_storage.rs
@@ -1,0 +1,125 @@
+use std::collections::HashSet;
+
+use bytes::Bytes;
+
+use crate::cached_crate_storage::DynStorage;
+use crate::storage::ObjectWithMeta;
+use crate::storage_error::StorageError;
+
+pub struct DocsStorage {
+    storage: DynStorage,
+}
+
+impl DocsStorage {
+    pub fn new(storage: DynStorage) -> Self {
+        Self { storage }
+    }
+
+    /// Key for one file under a crate+version's doc tree, e.g.
+    /// `file_key("my-crate", "1.0.0", "doc/my_crate/index.html")`.
+    pub fn file_key(crate_name: &str, version: &str, relative_path: &str) -> String {
+        format!("{crate_name}/{version}/{relative_path}")
+    }
+
+    pub fn version_prefix(crate_name: &str, version: &str) -> String {
+        format!("{crate_name}/{version}/")
+    }
+
+    pub fn crate_prefix(crate_name: &str) -> String {
+        format!("{crate_name}/")
+    }
+
+    pub async fn put(&self, key: &str, data: Bytes) -> Result<(), StorageError> {
+        self.storage
+            .put_overwrite(key, data)
+            .await
+            .map_err(|e| StorageError::DocsStoreFailed {
+                key: key.to_string(),
+                reason: e.to_string(),
+            })
+    }
+
+    pub async fn get(&self, key: &str) -> Result<Bytes, StorageError> {
+        self.storage.get(key).await.map_err(|e| {
+            if matches!(
+                &e,
+                StorageError::S3Error(object_store::Error::NotFound { .. })
+                    | StorageError::FileDoesNotExist(_)
+            ) {
+                return StorageError::DocsNotFound {
+                    key: key.to_string(),
+                };
+            }
+            StorageError::DocsGetFailed {
+                key: key.to_string(),
+                reason: e.to_string(),
+            }
+        })
+    }
+
+    pub async fn get_with_meta(&self, key: &str) -> Result<ObjectWithMeta, StorageError> {
+        self.storage.get_with_meta(key).await.map_err(|e| {
+            if matches!(
+                &e,
+                StorageError::S3Error(object_store::Error::NotFound { .. })
+                    | StorageError::FileDoesNotExist(_)
+            ) {
+                return StorageError::DocsNotFound {
+                    key: key.to_string(),
+                };
+            }
+            StorageError::DocsGetFailed {
+                key: key.to_string(),
+                reason: e.to_string(),
+            }
+        })
+    }
+
+    pub async fn exists(&self, key: &str) -> Result<bool, StorageError> {
+        self.storage.exists(key).await
+    }
+
+    pub async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        self.storage
+            .delete(key)
+            .await
+            .map_err(|e| StorageError::DocsDeleteFailed {
+                key: key.to_string(),
+                reason: e.to_string(),
+            })
+    }
+
+    pub async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        self.storage
+            .list(prefix)
+            .await
+            .map_err(|e| StorageError::DocsListFailed {
+                prefix: prefix.to_string(),
+                reason: e.to_string(),
+            })
+    }
+
+    /// Delete every key under `prefix` (used for crate/version teardown).
+    pub async fn delete_prefix(&self, prefix: &str) -> Result<(), StorageError> {
+        for key in self.list(prefix).await? {
+            self.delete(&key).await?;
+        }
+        Ok(())
+    }
+
+    /// Distinct version-folder names that have *any* key under `crate_name/`.
+    /// Callers still need to verify a given version actually has an
+    /// `index.html` — this only enumerates candidates.
+    pub async fn version_candidates(&self, crate_name: &str) -> Result<Vec<String>, StorageError> {
+        let prefix = Self::crate_prefix(crate_name);
+        let mut versions = HashSet::new();
+        for key in self.list(&prefix).await? {
+            if let Some(rest) = key.strip_prefix(&prefix)
+                && let Some(v) = rest.split('/').next()
+            {
+                versions.insert(v.to_string());
+            }
+        }
+        Ok(versions.into_iter().collect())
+    }
+}

--- a/crates/storage/src/fs_storage.rs
+++ b/crates/storage/src/fs_storage.rs
@@ -2,11 +2,12 @@ use std::fs::DirBuilder;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures_util::StreamExt;
 use object_store::local::LocalFileSystem;
 use object_store::path::Path;
 use object_store::{ObjectStore, ObjectStoreExt, PutMode};
 
-use crate::storage::Storage;
+use crate::storage::{ObjectWithMeta, Storage};
 use crate::storage_error::StorageError;
 
 pub struct FSStorage(LocalFileSystem);
@@ -22,9 +23,28 @@ impl Storage for FSStorage {
             .map_err(StorageError::from)
     }
 
+    async fn get_with_meta(&self, key: &str) -> Result<ObjectWithMeta, StorageError> {
+        let result = self.storage().get(&Path::from(key)).await?;
+        let e_tag = result.meta.e_tag.clone();
+        let last_modified = result.meta.last_modified;
+        let bytes = result.bytes().await?;
+        Ok(ObjectWithMeta {
+            bytes,
+            e_tag,
+            last_modified,
+        })
+    }
+
     async fn put(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
         self.storage()
             .put_opts(&Path::from(key), object.into(), PutMode::Create.into())
+            .await?;
+        Ok(())
+    }
+
+    async fn put_overwrite(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
+        self.storage()
+            .put_opts(&Path::from(key), object.into(), PutMode::Overwrite.into())
             .await?;
         Ok(())
     }
@@ -43,6 +63,20 @@ impl Storage for FSStorage {
                 object_store::Error::NotFound { .. } => Ok(false),
                 _ => Err(StorageError::from(e)),
             })
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        let prefix = if prefix.is_empty() {
+            None
+        } else {
+            Some(Path::from(prefix))
+        };
+        let mut stream = self.storage().list(prefix.as_ref());
+        let mut keys = Vec::new();
+        while let Some(meta) = stream.next().await {
+            keys.push(meta?.location.to_string());
+        }
+        Ok(keys)
     }
 }
 

--- a/crates/storage/src/gcs_storage.rs
+++ b/crates/storage/src/gcs_storage.rs
@@ -2,12 +2,13 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures_util::StreamExt;
 use kellnr_settings::Settings;
 use object_store::gcp::{GoogleCloudStorage, GoogleCloudStorageBuilder};
 use object_store::path::Path;
 use object_store::{ClientOptions, ObjectStore, ObjectStoreExt, PutMode};
 
-use crate::storage::Storage;
+use crate::storage::{ObjectWithMeta, Storage};
 use crate::storage_error::StorageError;
 
 pub struct GCSStorage(GoogleCloudStorage);
@@ -23,12 +24,35 @@ impl Storage for GCSStorage {
             .map_err(StorageError::from)
     }
 
+    async fn get_with_meta(&self, key: &str) -> Result<ObjectWithMeta, StorageError> {
+        let result = self.storage().get(&Self::try_path_from(key)?).await?;
+        let e_tag = result.meta.e_tag.clone();
+        let last_modified = result.meta.last_modified;
+        let bytes = result.bytes().await?;
+        Ok(ObjectWithMeta {
+            bytes,
+            e_tag,
+            last_modified,
+        })
+    }
+
     async fn put(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
         self.storage()
             .put_opts(
                 &Self::try_path_from(key)?,
                 object.into(),
                 PutMode::Create.into(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn put_overwrite(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
+        self.storage()
+            .put_opts(
+                &Self::try_path_from(key)?,
+                object.into(),
+                PutMode::Overwrite.into(),
             )
             .await?;
         Ok(())
@@ -50,6 +74,20 @@ impl Storage for GCSStorage {
                 object_store::Error::NotFound { .. } => Ok(false),
                 _ => Err(StorageError::from(e)),
             })
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        let prefix = if prefix.is_empty() {
+            None
+        } else {
+            Some(Self::try_path_from(prefix)?)
+        };
+        let mut stream = self.storage().list(prefix.as_ref());
+        let mut keys = Vec::new();
+        while let Some(meta) = stream.next().await {
+            keys.push(meta?.location.to_string());
+        }
+        Ok(keys)
     }
 }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cached_crate_storage;
 pub mod cratesio_crate_storage;
+pub mod docs_storage;
 pub mod fs_storage;
 pub mod gcs_storage;
 pub mod kellnr_crate_storage;

--- a/crates/storage/src/s3_storage.rs
+++ b/crates/storage/src/s3_storage.rs
@@ -2,12 +2,13 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures_util::StreamExt;
 use kellnr_settings::Settings;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path;
 use object_store::{ClientOptions, ObjectStore, ObjectStoreExt, PutMode};
 
-use crate::storage::Storage;
+use crate::storage::{ObjectWithMeta, Storage};
 use crate::storage_error::StorageError;
 
 pub struct S3Storage(AmazonS3);
@@ -23,12 +24,35 @@ impl Storage for S3Storage {
             .map_err(StorageError::from)
     }
 
+    async fn get_with_meta(&self, key: &str) -> Result<ObjectWithMeta, StorageError> {
+        let result = self.storage().get(&Self::try_path_from(key)?).await?;
+        let e_tag = result.meta.e_tag.clone();
+        let last_modified = result.meta.last_modified;
+        let bytes = result.bytes().await?;
+        Ok(ObjectWithMeta {
+            bytes,
+            e_tag,
+            last_modified,
+        })
+    }
+
     async fn put(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
         self.storage()
             .put_opts(
                 &Self::try_path_from(key)?,
                 object.into(),
                 PutMode::Create.into(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn put_overwrite(&self, key: &str, object: Bytes) -> Result<(), StorageError> {
+        self.storage()
+            .put_opts(
+                &Self::try_path_from(key)?,
+                object.into(),
+                PutMode::Overwrite.into(),
             )
             .await?;
         Ok(())
@@ -50,6 +74,20 @@ impl Storage for S3Storage {
                 object_store::Error::NotFound { .. } => Ok(false),
                 _ => Err(StorageError::from(e)),
             })
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        let prefix = if prefix.is_empty() {
+            None
+        } else {
+            Some(Self::try_path_from(prefix)?)
+        };
+        let mut stream = self.storage().list(prefix.as_ref());
+        let mut keys = Vec::new();
+        while let Some(meta) = stream.next().await {
+            keys.push(meta?.location.to_string());
+        }
+        Ok(keys)
     }
 }
 

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -1,12 +1,31 @@
 use async_trait::async_trait;
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 
 use crate::storage_error::StorageError;
+
+/// An object's bytes alongside the metadata needed for HTTP conditional-GET
+/// (`ETag`/`Last-Modified`) support.
+pub struct ObjectWithMeta {
+    pub bytes: Bytes,
+    pub e_tag: Option<String>,
+    pub last_modified: DateTime<Utc>,
+}
 
 #[async_trait]
 pub trait Storage {
     async fn get(&self, key: &str) -> Result<Bytes, StorageError>;
+    /// Like [`Storage::get`], but also returns the `ETag`/`Last-Modified`
+    /// metadata `object_store` already computes for every backend, so
+    /// callers can support conditional-GET without a second round-trip.
+    async fn get_with_meta(&self, key: &str) -> Result<ObjectWithMeta, StorageError>;
     async fn put(&self, key: &str, object: Bytes) -> Result<(), StorageError>;
+    /// Like [`Storage::put`], but overwrites an existing key instead of
+    /// failing. Needed for content that is republished in place (e.g. docs),
+    /// unlike crate tarballs/toolchain archives which are immutable.
+    async fn put_overwrite(&self, key: &str, object: Bytes) -> Result<(), StorageError>;
     async fn delete(&self, key: &str) -> Result<(), StorageError>;
     async fn exists(&self, key: &str) -> Result<bool, StorageError>;
+    /// Recursively list every key stored under `prefix`.
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError>;
 }

--- a/crates/storage/src/storage_error.rs
+++ b/crates/storage/src/storage_error.rs
@@ -63,4 +63,14 @@ pub enum StorageError {
     ToolchainGetFailed { path: String, reason: String },
     #[error("Failed to delete toolchain archive {path}: {reason}")]
     ToolchainDeleteFailed { path: String, reason: String },
+    #[error("Docs file not found: {key}")]
+    DocsNotFound { key: String },
+    #[error("Failed to store docs file {key}: {reason}")]
+    DocsStoreFailed { key: String, reason: String },
+    #[error("Failed to retrieve docs file {key}: {reason}")]
+    DocsGetFailed { key: String, reason: String },
+    #[error("Failed to delete docs file {key}: {reason}")]
+    DocsDeleteFailed { key: String, reason: String },
+    #[error("Failed to list docs under prefix {prefix}: {reason}")]
+    DocsListFailed { prefix: String, reason: String },
 }

--- a/crates/storage/tests/fs_tests.rs
+++ b/crates/storage/tests/fs_tests.rs
@@ -1,0 +1,198 @@
+use bytes::Bytes;
+use kellnr_storage::docs_storage::DocsStorage;
+use kellnr_storage::fs_storage::FSStorage;
+use kellnr_storage::storage::Storage;
+
+fn temp_storage() -> (tempfile::TempDir, FSStorage) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = FSStorage::new(dir.path().to_str().unwrap()).unwrap();
+    (dir, storage)
+}
+
+#[tokio::test]
+async fn put_then_get_roundtrips() {
+    let (_dir, storage) = temp_storage();
+    storage
+        .put("a/b.txt", Bytes::from_static(b"hello"))
+        .await
+        .unwrap();
+
+    let data = storage.get("a/b.txt").await.unwrap();
+    assert_eq!(data, Bytes::from_static(b"hello"));
+}
+
+#[tokio::test]
+async fn get_with_meta_returns_bytes_etag_and_last_modified() {
+    let (_dir, storage) = temp_storage();
+    storage
+        .put("a/b.txt", Bytes::from_static(b"hello"))
+        .await
+        .unwrap();
+
+    let object = storage.get_with_meta("a/b.txt").await.unwrap();
+
+    assert_eq!(object.bytes, Bytes::from_static(b"hello"));
+    assert!(object.e_tag.is_some());
+    assert!(object.last_modified <= chrono::Utc::now());
+}
+
+#[tokio::test]
+async fn put_fails_if_key_already_exists() {
+    let (_dir, storage) = temp_storage();
+    storage
+        .put("a/b.txt", Bytes::from_static(b"first"))
+        .await
+        .unwrap();
+
+    let result = storage.put("a/b.txt", Bytes::from_static(b"second")).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn put_overwrite_replaces_existing_key() {
+    let (_dir, storage) = temp_storage();
+    storage
+        .put("a/b.txt", Bytes::from_static(b"first"))
+        .await
+        .unwrap();
+
+    storage
+        .put_overwrite("a/b.txt", Bytes::from_static(b"second"))
+        .await
+        .unwrap();
+
+    let data = storage.get("a/b.txt").await.unwrap();
+    assert_eq!(data, Bytes::from_static(b"second"));
+}
+
+#[tokio::test]
+async fn delete_removes_key() {
+    let (_dir, storage) = temp_storage();
+    storage
+        .put("a/b.txt", Bytes::from_static(b"hello"))
+        .await
+        .unwrap();
+
+    storage.delete("a/b.txt").await.unwrap();
+
+    assert!(!storage.exists("a/b.txt").await.unwrap());
+}
+
+#[tokio::test]
+async fn list_is_recursive_under_prefix() {
+    let (_dir, storage) = temp_storage();
+    storage
+        .put("crate/1.0.0/doc/index.html", Bytes::from_static(b"a"))
+        .await
+        .unwrap();
+    storage
+        .put("crate/1.0.0/doc/nested/page.html", Bytes::from_static(b"b"))
+        .await
+        .unwrap();
+    storage
+        .put("crate/2.0.0/doc/index.html", Bytes::from_static(b"c"))
+        .await
+        .unwrap();
+    storage
+        .put("other-crate/1.0.0/doc/index.html", Bytes::from_static(b"d"))
+        .await
+        .unwrap();
+
+    let mut keys = storage.list("crate/1.0.0/").await.unwrap();
+    keys.sort();
+
+    assert_eq!(
+        keys,
+        vec![
+            "crate/1.0.0/doc/index.html".to_string(),
+            "crate/1.0.0/doc/nested/page.html".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn list_does_not_match_sibling_prefix_with_shared_string_prefix() {
+    let (_dir, storage) = temp_storage();
+    storage
+        .put("foo/1.0.0/index.html", Bytes::from_static(b"a"))
+        .await
+        .unwrap();
+    storage
+        .put("foo-bar/1.0.0/index.html", Bytes::from_static(b"b"))
+        .await
+        .unwrap();
+
+    let keys = storage.list("foo/").await.unwrap();
+
+    assert_eq!(keys, vec!["foo/1.0.0/index.html".to_string()]);
+}
+
+#[tokio::test]
+async fn list_returns_empty_for_missing_prefix() {
+    let (_dir, storage) = temp_storage();
+    let keys = storage.list("does-not-exist/").await.unwrap();
+    assert!(keys.is_empty());
+}
+
+fn docs_storage() -> (tempfile::TempDir, DocsStorage) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = FSStorage::new(dir.path().to_str().unwrap()).unwrap();
+    (dir, DocsStorage::new(Box::new(storage)))
+}
+
+#[tokio::test]
+async fn docs_storage_put_overwrites_and_gets() {
+    let (_dir, docs) = docs_storage();
+    let key = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+
+    docs.put(&key, Bytes::from_static(b"v1")).await.unwrap();
+    docs.put(&key, Bytes::from_static(b"v2")).await.unwrap();
+
+    let data = docs.get(&key).await.unwrap();
+    assert_eq!(data, Bytes::from_static(b"v2"));
+}
+
+#[tokio::test]
+async fn docs_storage_delete_prefix_removes_only_matching_version() {
+    let (_dir, docs) = docs_storage();
+    let v1 = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+    let v2 = DocsStorage::file_key("my-crate", "2.0.0", "doc/my_crate/index.html");
+
+    docs.put(&v1, Bytes::from_static(b"a")).await.unwrap();
+    docs.put(&v2, Bytes::from_static(b"b")).await.unwrap();
+
+    docs.delete_prefix(&DocsStorage::version_prefix("my-crate", "1.0.0"))
+        .await
+        .unwrap();
+
+    assert!(!docs.exists(&v1).await.unwrap());
+    assert!(docs.exists(&v2).await.unwrap());
+}
+
+#[tokio::test]
+async fn docs_storage_version_candidates_lists_distinct_versions() {
+    let (_dir, docs) = docs_storage();
+    docs.put(
+        &DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html"),
+        Bytes::from_static(b"a"),
+    )
+    .await
+    .unwrap();
+    docs.put(
+        &DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/other.html"),
+        Bytes::from_static(b"b"),
+    )
+    .await
+    .unwrap();
+    docs.put(
+        &DocsStorage::file_key("my-crate", "2.0.0", "doc/my_crate/index.html"),
+        Bytes::from_static(b"c"),
+    )
+    .await
+    .unwrap();
+
+    let mut versions = docs.version_candidates("my-crate").await.unwrap();
+    versions.sort();
+
+    assert_eq!(versions, vec!["1.0.0".to_string(), "2.0.0".to_string()]);
+}

--- a/crates/storage/tests/gcs_tests.rs
+++ b/crates/storage/tests/gcs_tests.rs
@@ -8,10 +8,33 @@ use kellnr_fakegcs_testcontainer::*;
 use kellnr_settings::Settings;
 use kellnr_settings::gcs::Gcs;
 use kellnr_storage::cached_crate_storage::DynStorage;
+use kellnr_storage::docs_storage::DocsStorage;
 use kellnr_storage::gcs_storage::GCSStorage;
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 #[path = "gcs_image.rs"]
 mod image;
+
+fn test_settings(data_dir: &str, url: &str) -> Settings {
+    Settings {
+        registry: kellnr_settings::Registry {
+            data_dir: data_dir.to_owned(),
+            session_age_seconds: 60,
+            ..kellnr_settings::Registry::default()
+        },
+        setup: kellnr_settings::Setup {
+            admin_pwd: String::new(),
+            ..kellnr_settings::Setup::default()
+        },
+        gcs: Gcs {
+            enabled: true,
+            endpoint: Some(url.to_string()),
+            allow_http: true,
+            skip_signature: true,
+            ..Gcs::default()
+        },
+        ..Settings::default()
+    }
+}
 
 struct TestGCSStorage {
     crate_storage: KellnrCrateStorage,
@@ -19,30 +42,18 @@ struct TestGCSStorage {
 
 impl TestGCSStorage {
     fn from(data_dir: &str, url: &str) -> TestGCSStorage {
-        let settings = Settings {
-            registry: kellnr_settings::Registry {
-                data_dir: data_dir.to_owned(),
-                session_age_seconds: 60,
-                ..kellnr_settings::Registry::default()
-            },
-            setup: kellnr_settings::Setup {
-                admin_pwd: String::new(),
-                ..kellnr_settings::Setup::default()
-            },
-            gcs: Gcs {
-                enabled: true,
-                endpoint: Some(url.to_string()),
-                allow_http: true,
-                skip_signature: true,
-                ..Gcs::default()
-            },
-            ..Settings::default()
-        };
+        let settings = test_settings(data_dir, url);
         let storage =
             Box::new(GCSStorage::try_from(("kellnr-crates", &settings)).unwrap()) as DynStorage;
         let crate_storage = KellnrCrateStorage::new(&settings, storage);
         TestGCSStorage { crate_storage }
     }
+}
+
+fn test_docs_storage(data_dir: &str, url: &str) -> DocsStorage {
+    let settings = test_settings(data_dir, url);
+    let storage = Box::new(GCSStorage::try_from(("kellnr-docs", &settings)).unwrap()) as DynStorage;
+    DocsStorage::new(storage)
 }
 
 #[fakegcs_testcontainer]
@@ -92,4 +103,46 @@ async fn remove_crate() {
     let res = test_storage.crate_storage.delete(&name, &version).await;
 
     assert!(res.is_ok());
+}
+
+#[fakegcs_testcontainer]
+#[tokio::test]
+async fn docs_storage_delete_prefix_removes_only_matching_version() {
+    // `localhost`, not `container.get_host()`: see the comment on `add_and_get_crate`.
+    let url = format!("http://localhost:{port}");
+    let docs = test_docs_storage("test_docs_delete_prefix_gcs", &url);
+
+    let v1 = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+    let v2 = DocsStorage::file_key("my-crate", "2.0.0", "doc/my_crate/index.html");
+    docs.put(&v1, bytes::Bytes::from_static(b"a"))
+        .await
+        .unwrap();
+    docs.put(&v2, bytes::Bytes::from_static(b"b"))
+        .await
+        .unwrap();
+
+    docs.delete_prefix(&DocsStorage::version_prefix("my-crate", "1.0.0"))
+        .await
+        .unwrap();
+
+    assert!(!docs.exists(&v1).await.unwrap());
+    assert!(docs.exists(&v2).await.unwrap());
+}
+
+#[fakegcs_testcontainer]
+#[tokio::test]
+async fn get_with_meta_returns_bytes_etag_and_last_modified() {
+    // `localhost`, not `container.get_host()`: see the comment on `add_and_get_crate`.
+    let url = format!("http://localhost:{port}");
+    let docs = test_docs_storage("test_docs_get_with_meta_gcs", &url);
+    let key = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+    docs.put(&key, bytes::Bytes::from_static(b"hello"))
+        .await
+        .unwrap();
+
+    let object = docs.get_with_meta(&key).await.unwrap();
+
+    assert_eq!(object.bytes, bytes::Bytes::from_static(b"hello"));
+    assert!(object.e_tag.is_some());
+    assert!(object.last_modified <= chrono::Utc::now());
 }

--- a/crates/storage/tests/image.rs
+++ b/crates/storage/tests/image.rs
@@ -58,7 +58,7 @@ impl Image for RustFs {
         vec![
             "-c",
             concat!(
-                "mkdir -p /data/kellnr-crates && ",
+                "mkdir -p /data/kellnr-crates /data/kellnr-cratesio /data/kellnr-toolchains /data/kellnr-docs && ",
                 "exec /usr/bin/rustfs ",
                 "--access-key rustfsadmin ",
                 "--secret-key rustfsadmin ",

--- a/crates/storage/tests/s3_tests.rs
+++ b/crates/storage/tests/s3_tests.rs
@@ -8,9 +8,33 @@ use kellnr_rustfs_testcontainer::*;
 use kellnr_settings::Settings;
 use kellnr_settings::s3::S3;
 use kellnr_storage::cached_crate_storage::DynStorage;
+use kellnr_storage::docs_storage::DocsStorage;
 use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
 use kellnr_storage::s3_storage::S3Storage;
 mod image;
+
+fn test_settings(data_dir: &str, url: &str) -> Settings {
+    Settings {
+        registry: kellnr_settings::Registry {
+            data_dir: data_dir.to_owned(),
+            session_age_seconds: 60,
+            ..kellnr_settings::Registry::default()
+        },
+        setup: kellnr_settings::Setup {
+            admin_pwd: String::new(),
+            ..kellnr_settings::Setup::default()
+        },
+        s3: S3 {
+            enabled: true,
+            access_key: Some("rustfsadmin".into()),
+            secret_key: Some("rustfsadmin".into()),
+            endpoint: Some(url.to_string()),
+            allow_http: true,
+            ..S3::default()
+        },
+        ..Settings::default()
+    }
+}
 
 struct TestS3Storage {
     crate_storage: KellnrCrateStorage,
@@ -18,31 +42,18 @@ struct TestS3Storage {
 
 impl TestS3Storage {
     fn from(data_dir: &str, url: &str) -> TestS3Storage {
-        let settings = Settings {
-            registry: kellnr_settings::Registry {
-                data_dir: data_dir.to_owned(),
-                session_age_seconds: 60,
-                ..kellnr_settings::Registry::default()
-            },
-            setup: kellnr_settings::Setup {
-                admin_pwd: String::new(),
-                ..kellnr_settings::Setup::default()
-            },
-            s3: S3 {
-                enabled: true,
-                access_key: Some("rustfsadmin".into()),
-                secret_key: Some("rustfsadmin".into()),
-                endpoint: Some(url.to_string()),
-                allow_http: true,
-                ..S3::default()
-            },
-            ..Settings::default()
-        };
+        let settings = test_settings(data_dir, url);
         let storage =
             Box::new(S3Storage::try_from(("kellnr-crates", &settings)).unwrap()) as DynStorage;
         let crate_storage = KellnrCrateStorage::new(&settings, storage);
         TestS3Storage { crate_storage }
     }
+}
+
+fn test_docs_storage(data_dir: &str, url: &str) -> DocsStorage {
+    let settings = test_settings(data_dir, url);
+    let storage = Box::new(S3Storage::try_from(("kellnr-docs", &settings)).unwrap()) as DynStorage;
+    DocsStorage::new(storage)
 }
 
 #[rustfs_testcontainer]
@@ -91,4 +102,46 @@ async fn remove_crate() {
     let res = test_storage.crate_storage.delete(&name, &version).await;
 
     assert!(res.is_ok());
+}
+
+#[rustfs_testcontainer]
+#[tokio::test]
+async fn docs_storage_delete_prefix_removes_only_matching_version() {
+    let host = container.get_host().await.unwrap().to_string();
+    let url = format!("http://{host}:{port}");
+    let docs = test_docs_storage("test_docs_delete_prefix", &url);
+
+    let v1 = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+    let v2 = DocsStorage::file_key("my-crate", "2.0.0", "doc/my_crate/index.html");
+    docs.put(&v1, bytes::Bytes::from_static(b"a"))
+        .await
+        .unwrap();
+    docs.put(&v2, bytes::Bytes::from_static(b"b"))
+        .await
+        .unwrap();
+
+    docs.delete_prefix(&DocsStorage::version_prefix("my-crate", "1.0.0"))
+        .await
+        .unwrap();
+
+    assert!(!docs.exists(&v1).await.unwrap());
+    assert!(docs.exists(&v2).await.unwrap());
+}
+
+#[rustfs_testcontainer]
+#[tokio::test]
+async fn get_with_meta_returns_bytes_etag_and_last_modified() {
+    let host = container.get_host().await.unwrap().to_string();
+    let url = format!("http://{host}:{port}");
+    let docs = test_docs_storage("test_docs_get_with_meta", &url);
+    let key = DocsStorage::file_key("my-crate", "1.0.0", "doc/my_crate/index.html");
+    docs.put(&key, bytes::Bytes::from_static(b"hello"))
+        .await
+        .unwrap();
+
+    let object = docs.get_with_meta(&key).await.unwrap();
+
+    assert_eq!(object.bytes, bytes::Bytes::from_static(b"hello"));
+    assert!(object.e_tag.is_some());
+    assert!(object.last_modified <= chrono::Utc::now());
 }

--- a/crates/web-ui/Cargo.toml
+++ b/crates/web-ui/Cargo.toml
@@ -30,14 +30,16 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 urlencoding = "2"
 
 [dev-dependencies]
+bytes.workspace = true
 flume.workspace = true
 hyper.workspace = true
 mockall.workspace = true
-tokio.workspace = true
+tempfile.workspace = true
 tower.workspace = true
 
 [lints]

--- a/crates/web-ui/src/ui.rs
+++ b/crates/web-ui/src/ui.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use axum::Json;
@@ -11,6 +12,7 @@ use kellnr_common::normalized_name::NormalizedName;
 use kellnr_common::original_name::OriginalName;
 use kellnr_common::version::Version;
 use kellnr_db::error::DbError;
+use kellnr_docs::upload::upload_dir_and_prune;
 use kellnr_settings::{
     ConfigSource, Provenance, Settings, SettingsProv, SourceMap, cli_flag_map, compile_time_config,
     erased_serde, leaf_label, sources_from_prov,
@@ -412,7 +414,7 @@ async fn delete_crate_versions_impl(
             return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
         }
 
-        if let Err(e) = kellnr_docs::delete(name, version, &state.settings).await {
+        if let Err(e) = kellnr_docs::delete(name, version, &state.docs_storage).await {
             error!("Failed to delete crate from docs: {e}");
             return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
         }
@@ -647,6 +649,120 @@ pub async fn build_rustdoc(
     Ok(())
 }
 
+/// Response for [`migrate_docs_storage`].
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct MigrateDocsStorageResponse {
+    /// `false` when there was no local docs directory to migrate from.
+    pub started: bool,
+    /// Number of crate/version pairs found under the local docs directory.
+    pub crate_versions_found: usize,
+}
+
+/// Copy locally-stored docs into the configured S3/GCS docs bucket
+///
+/// One-time backfill for existing deployments that switch `s3.docs_bucket`/
+/// `gcs.docs_bucket` from unset to a bucket name: copies every file already
+/// on local disk (both auto-generated and manually-published docs use the
+/// same on-disk layout) into the now-configured backend. Non-destructive —
+/// local files are left in place, so this is safe to re-run. Runs in the
+/// background since a large registry can take minutes to copy; admin-only.
+#[utoipa::path(
+    post,
+    path = "/migrate-storage",
+    tag = "docs",
+    responses(
+        (status = 200, description = "No local docs found to migrate", body = MigrateDocsStorageResponse),
+        (status = 202, description = "Migration started in the background", body = MigrateDocsStorageResponse),
+        (status = 400, description = "Docs are still backed by local disk, nothing to migrate to"),
+        (status = 401, description = "Not authorized"),
+        (status = 403, description = "Not an admin")
+    ),
+    security(("session_cookie" = []))
+)]
+pub async fn migrate_docs_storage(
+    State(state): AppState,
+    _admin: AdminUser,
+) -> Result<(StatusCode, Json<MigrateDocsStorageResponse>), RouteError> {
+    if state.settings.docs_backend_is_local() {
+        return Err(RouteError::Status(StatusCode::BAD_REQUEST));
+    }
+
+    let docs_path = PathBuf::from(state.settings.docs_path());
+    let crate_versions = match list_local_crate_versions(&docs_path).await {
+        Ok(crate_versions) => crate_versions,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(e) => {
+            error!("Failed to read local docs directory {docs_path:?}: {e}");
+            return Err(RouteError::Status(StatusCode::INTERNAL_SERVER_ERROR));
+        }
+    };
+
+    if crate_versions.is_empty() {
+        return Ok((
+            StatusCode::OK,
+            Json(MigrateDocsStorageResponse {
+                started: false,
+                crate_versions_found: 0,
+            }),
+        ));
+    }
+
+    let crate_versions_found = crate_versions.len();
+    let docs_storage = state.docs_storage.clone();
+    tokio::spawn(async move {
+        for (crate_name, version, dir) in crate_versions {
+            match upload_dir_and_prune(&dir, "", &crate_name, &version, &docs_storage).await {
+                Ok(()) => {
+                    tracing::info!(
+                        "Migrated local docs for {crate_name} {version} to configured storage backend"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to migrate local docs for {crate_name} {version} to configured storage backend: {e}"
+                    );
+                }
+            }
+        }
+        tracing::info!(
+            "Finished docs storage migration for {crate_versions_found} crate/version(s)"
+        );
+    });
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(MigrateDocsStorageResponse {
+            started: true,
+            crate_versions_found,
+        }),
+    ))
+}
+
+/// Enumerate `{docs_path}/{crate_name}/{version}/` two levels deep. Cheap —
+/// only lists directory entries, doesn't read any doc file contents.
+async fn list_local_crate_versions(
+    docs_path: &std::path::Path,
+) -> std::io::Result<Vec<(String, String, PathBuf)>> {
+    let mut result = Vec::new();
+    let mut crate_dirs = tokio::fs::read_dir(docs_path).await?;
+    while let Some(crate_entry) = crate_dirs.next_entry().await? {
+        if !crate_entry.file_type().await?.is_dir() {
+            continue;
+        }
+        let crate_name = crate_entry.file_name().to_string_lossy().into_owned();
+
+        let mut version_dirs = tokio::fs::read_dir(crate_entry.path()).await?;
+        while let Some(version_entry) = version_dirs.next_entry().await? {
+            if !version_entry.file_type().await?.is_dir() {
+                continue;
+            }
+            let version = version_entry.file_name().to_string_lossy().into_owned();
+            result.push((crate_name.clone(), version, version_entry.path()));
+        }
+    }
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -656,6 +772,7 @@ mod tests {
     use axum::body::Body;
     use axum::routing::{get, post};
     use axum_extra::extract::cookie::Key;
+    use bytes::Bytes;
     use http_body_util::BodyExt;
     use hyper::{Request, header};
     use kellnr_appstate::AppStateData;
@@ -665,6 +782,7 @@ mod tests {
     use kellnr_db::mock::MockDb;
     use kellnr_settings::{Postgresql, Settings, constants};
     use kellnr_storage::cached_crate_storage::DynStorage;
+    use kellnr_storage::docs_storage::DocsStorage;
     use kellnr_storage::fs_storage::FSStorage;
     use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
     use mockall::predicate::*;
@@ -1220,6 +1338,236 @@ mod tests {
         .unwrap();
 
         assert_eq!(r.status(), StatusCode::OK);
+    }
+
+    fn migrate_storage_app(
+        mock_db: MockDb,
+        settings: Settings,
+        docs_storage: DocsStorage,
+    ) -> Router {
+        Router::new()
+            .route("/migrate-storage", post(migrate_docs_storage))
+            .with_state(AppStateData {
+                db: Arc::new(mock_db),
+                signing_key: Key::from(TEST_KEY),
+                settings: Arc::new(settings),
+                docs_storage: Arc::new(docs_storage),
+                ..kellnr_appstate::test_state()
+            })
+    }
+
+    fn fs_docs_storage(dir: &std::path::Path) -> DocsStorage {
+        DocsStorage::new(Box::new(FSStorage::new(dir.to_str().unwrap()).unwrap()) as DynStorage)
+    }
+
+    /// Settings with a bucket configured, i.e. `docs_backend_is_local() == false`.
+    /// Only settings-level config is exercised here (no real S3 network access):
+    /// the endpoint's actual copy destination is whatever `docs_storage` the
+    /// caller wires into `AppStateData`, independent of this bucket name.
+    fn settings_with_docs_bucket_configured(data_dir: &std::path::Path) -> Settings {
+        let mut settings = kellnr_settings::test_settings();
+        settings.registry.data_dir = data_dir.to_str().unwrap().to_string();
+        settings.s3.enabled = true;
+        settings.s3.docs_bucket = Some("kellnr-docs".to_string());
+        settings
+    }
+
+    fn admin_session_mock_db() -> MockDb {
+        let mut mock_db = MockDb::new();
+        mock_db.expect_validate_session().returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "admin".to_string(),
+                is_admin: true,
+                is_read_only: false,
+            })
+        });
+        mock_db
+    }
+
+    #[tokio::test]
+    async fn migrate_docs_storage_returns_401_without_session() {
+        let local = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let settings = settings_with_docs_bucket_configured(local.path());
+
+        let r = migrate_storage_app(MockDb::new(), settings, fs_docs_storage(target.path()))
+            .oneshot(
+                Request::post("/migrate-storage")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn migrate_docs_storage_returns_403_for_non_admin() {
+        let mut mock_db = MockDb::new();
+        mock_db.expect_validate_session().returning(|_| {
+            Ok(kellnr_db::SessionInfo {
+                name: "user".to_string(),
+                is_admin: false,
+                is_read_only: false,
+            })
+        });
+        let local = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let settings = settings_with_docs_bucket_configured(local.path());
+
+        let r = migrate_storage_app(mock_db, settings, fs_docs_storage(target.path()))
+            .oneshot(
+                Request::post("/migrate-storage")
+                    .header(
+                        header::COOKIE,
+                        encode_cookies([(constants::COOKIE_SESSION_ID, "cookie")]),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn migrate_docs_storage_returns_400_when_backend_is_local_disk() {
+        let local = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let mut settings = kellnr_settings::test_settings();
+        settings.registry.data_dir = local.path().to_str().unwrap().to_string();
+
+        let r = migrate_storage_app(
+            admin_session_mock_db(),
+            settings,
+            fs_docs_storage(target.path()),
+        )
+        .oneshot(
+            Request::post("/migrate-storage")
+                .header(
+                    header::COOKIE,
+                    encode_cookies([(constants::COOKIE_SESSION_ID, "cookie")]),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn migrate_docs_storage_returns_zero_count_when_local_dir_missing() {
+        let local = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        // `local` exists but nothing was ever generated locally, so
+        // `{data_dir}/docs` itself was never created.
+        let settings = settings_with_docs_bucket_configured(local.path());
+
+        let r = migrate_storage_app(
+            admin_session_mock_db(),
+            settings,
+            fs_docs_storage(target.path()),
+        )
+        .oneshot(
+            Request::post("/migrate-storage")
+                .header(
+                    header::COOKIE,
+                    encode_cookies([(constants::COOKIE_SESSION_ID, "cookie")]),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(r.status(), StatusCode::OK);
+        let body = r.into_body().collect().await.unwrap().to_bytes();
+        let response: MigrateDocsStorageResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!response.started);
+        assert_eq!(response.crate_versions_found, 0);
+    }
+
+    #[tokio::test]
+    async fn migrate_docs_storage_copies_local_docs_into_configured_backend() {
+        let local = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let settings = settings_with_docs_bucket_configured(local.path());
+
+        // Both auto-generated and manually-published docs land in this exact
+        // on-disk layout (see `upload_dir_and_prune`), so one local crate/
+        // version dir stands in for either origin.
+        let docs_path_string = settings.docs_path();
+        let docs_path = std::path::Path::new(&docs_path_string);
+        tokio::fs::create_dir_all(docs_path.join("crate-a/1.0.0/doc"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            docs_path.join("crate-a/1.0.0/doc/index.html"),
+            b"crate-a docs",
+        )
+        .await
+        .unwrap();
+        tokio::fs::create_dir_all(docs_path.join("crate-b/2.0.0/doc/nested"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            docs_path.join("crate-b/2.0.0/doc/nested/page.html"),
+            b"crate-b nested docs",
+        )
+        .await
+        .unwrap();
+
+        let target_docs_storage = fs_docs_storage(target.path());
+        let r = migrate_storage_app(
+            admin_session_mock_db(),
+            settings,
+            // `migrate_storage_app` wraps this in the `Arc` the handler needs,
+            // but we still need our own handle on the same backing directory
+            // to assert on afterwards, so build a second `DocsStorage` on top
+            // of the same `target` directory rather than reusing the moved value.
+            fs_docs_storage(target.path()),
+        )
+        .oneshot(
+            Request::post("/migrate-storage")
+                .header(
+                    header::COOKIE,
+                    encode_cookies([(constants::COOKIE_SESSION_ID, "cookie")]),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(r.status(), StatusCode::ACCEPTED);
+        let body = r.into_body().collect().await.unwrap().to_bytes();
+        let response: MigrateDocsStorageResponse = serde_json::from_slice(&body).unwrap();
+        assert!(response.started);
+        assert_eq!(response.crate_versions_found, 2);
+
+        let key_a = DocsStorage::file_key("crate-a", "1.0.0", "doc/index.html");
+        let key_b = DocsStorage::file_key("crate-b", "2.0.0", "doc/nested/page.html");
+        for _ in 0..50 {
+            if target_docs_storage.exists(&key_a).await.unwrap()
+                && target_docs_storage.exists(&key_b).await.unwrap()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(
+            target_docs_storage.get(&key_a).await.unwrap(),
+            Bytes::from_static(b"crate-a docs")
+        );
+        assert_eq!(
+            target_docs_storage.get(&key_b).await.unwrap(),
+            Bytes::from_static(b"crate-b nested docs")
+        );
     }
 
     #[tokio::test]

--- a/crates/web-ui/src/user.rs
+++ b/crates/web-ui/src/user.rs
@@ -519,6 +519,7 @@ mod tests {
     use kellnr_settings::constants::COOKIE_SESSION_ID;
     use kellnr_storage::cached_crate_storage::DynStorage;
     use kellnr_storage::cratesio_crate_storage::CratesIoCrateStorage;
+    use kellnr_storage::docs_storage::DocsStorage;
     use kellnr_storage::fs_storage::FSStorage;
     use kellnr_storage::kellnr_crate_storage::KellnrCrateStorage;
     use mockall::predicate::*;
@@ -536,6 +537,9 @@ mod tests {
             &settings,
             Box::new(FSStorage::new(&settings.crates_io_path()).unwrap()) as DynStorage,
         ));
+        let docs_storage = Arc::new(DocsStorage::new(Box::new(
+            FSStorage::new(&settings.docs_path()).unwrap(),
+        ) as DynStorage));
         let (cratesio_prefetch_sender, _) = flume::unbounded();
         let db: Arc<dyn kellnr_db::DbProvider> = Arc::new(mock_db);
         let download_counter = Arc::new(kellnr_db::download_counter::DownloadCounter::new(
@@ -550,6 +554,7 @@ mod tests {
             settings_prov: kellnr_appstate::default_settings_prov(),
             crate_storage,
             cratesio_storage,
+            docs_storage,
             cratesio_prefetch_sender,
             token_cache: cache,
             toolchain_storage: None,

--- a/tests/fixtures/test-gcs-storage/Dockerfile
+++ b/tests/fixtures/test-gcs-storage/Dockerfile
@@ -36,11 +36,12 @@ FROM alpine:3.22
 ARG CRATES_BUCKET=kellnr-crates
 ARG CRATESIO_BUCKET=kellnr-cratesio
 ARG TOOLCHAIN_BUCKET=kellnr-toolchains
+ARG DOCS_BUCKET=kellnr-docs
 
 COPY --from=build /fake-gcs-server /bin/fake-gcs-server
 
 # fake-gcs-server pre-seeds buckets from directories under /data
-RUN mkdir -p /data/${CRATES_BUCKET} /data/${CRATESIO_BUCKET} /data/${TOOLCHAIN_BUCKET}
+RUN mkdir -p /data/${CRATES_BUCKET} /data/${CRATESIO_BUCKET} /data/${TOOLCHAIN_BUCKET} /data/${DOCS_BUCKET}
 
 # Run in HTTP mode (no TLS) so kellnr can talk to it without a trusted cert, and skip
 # request signing on the kellnr side (fake-gcs-server does not validate auth by default).

--- a/ui/src/types/settings.ts
+++ b/ui/src/types/settings.ts
@@ -133,6 +133,7 @@ export type S3 = {
   crates_bucket: string
   cratesio_bucket: string
   toolchain_bucket: string
+  docs_bucket: string | null
   connect_timeout_seconds: number
   request_timeout_seconds: number
 }
@@ -145,6 +146,7 @@ export type Gcs = {
   crates_bucket: string
   cratesio_bucket: string
   toolchain_bucket: string
+  docs_bucket: string | null
   connect_timeout_seconds: number
   request_timeout_seconds: number
 }
@@ -162,6 +164,7 @@ export const emptySettings: Settings = {
     crates_bucket: "",
     cratesio_bucket: "",
     toolchain_bucket: "",
+    docs_bucket: null,
     connect_timeout_seconds: 5,
     request_timeout_seconds: 30
   },
@@ -227,6 +230,7 @@ export const emptySettings: Settings = {
     crates_bucket: "",
     cratesio_bucket: "",
     toolchain_bucket: "",
+    docs_bucket: null,
     connect_timeout_seconds: 5,
     request_timeout_seconds: 30
   },


### PR DESCRIPTION
Docs (rustdoc) were hardcoded to local disk via ServeDir, so deployments without persistent local storage (e.g. GCS-backed) lost generated docs and served 404s. Thread doc generation, manual publishing, and serving through the same Storage trait already used for crates/cratesio/toolchains, via a new DocsStorage wrapper with overwrite-on-publish semantics.

Bundled fix: a corrupt/path-traversal doc archive's extraction error was silently discarded, always returning 200; it now surfaces as 400.