### PR TITLE
fix(api): enforce the search query length bound on both entry points

### DIFF
--- a/crates/common/src/name_or_description.rs
+++ b/crates/common/src/name_or_description.rs
@@ -1,21 +1,47 @@
+use std::ops::Deref;
+
 use thiserror::Error;
 use utoipa::ToSchema;
 
+/// A free-form crate search query, matched against crate names and descriptions.
+///
+/// Unlike [`crate::original_name::OriginalName`] the content is not restricted
+/// to crate-name characters, because a description search takes arbitrary text.
+/// Only the length is bounded, so an oversized query cannot turn into an
+/// oversized `LIKE` pattern scanned across every row.
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone, Hash, ToSchema)]
 #[schema(value_type = String)]
-pub struct NameOrDescription(pub String);
+// Validate on every deserialization (query strings, JSON bodies) instead of only
+// in the explicit `TryFrom` constructor. Otherwise serde-based extractors such as
+// the web UI's `Query<SearchParams>` bypass the length bound entirely. Mirrors
+// the custom `Deserialize` on `OriginalName`.
+#[serde(try_from = "String")]
+pub struct NameOrDescription(String);
+
+/// Upper bound on a search query, in characters.
+const MAX_LEN: usize = 64;
 
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum NameOrDescriptionError {
-    #[error("Invalid length")]
+    #[error("Search query must not be longer than {MAX_LEN} characters")]
     InvalidLength,
+}
+
+impl NameOrDescription {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 impl TryFrom<String> for NameOrDescription {
     type Error = NameOrDescriptionError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.len() > 64 {
+        if value.chars().count() > MAX_LEN {
             Err(NameOrDescriptionError::InvalidLength)
         } else {
             Ok(Self(value))
@@ -23,8 +49,79 @@ impl TryFrom<String> for NameOrDescription {
     }
 }
 
+impl TryFrom<&str> for NameOrDescription {
+    type Error = NameOrDescriptionError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_string())
+    }
+}
+
 impl From<NameOrDescription> for String {
     fn from(value: NameOrDescription) -> Self {
         value.0
+    }
+}
+
+impl Deref for NameOrDescription {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_arbitrary_text() {
+        assert_eq!(
+            NameOrDescription::try_from("vcard parser")
+                .unwrap()
+                .as_str(),
+            "vcard parser"
+        );
+    }
+
+    #[test]
+    fn accepts_query_at_the_limit() {
+        let query = "a".repeat(MAX_LEN);
+        assert_eq!(
+            NameOrDescription::try_from(query.clone()).unwrap().as_str(),
+            query
+        );
+    }
+
+    #[test]
+    fn rejects_query_over_the_limit() {
+        let query = "a".repeat(MAX_LEN + 1);
+        assert_eq!(
+            NameOrDescription::try_from(query),
+            Err(NameOrDescriptionError::InvalidLength)
+        );
+    }
+
+    // The bound counts characters, not bytes, so a query of multi-byte
+    // characters is not rejected earlier than an ASCII one of the same length.
+    #[test]
+    fn counts_characters_not_bytes() {
+        let query = "ä".repeat(MAX_LEN);
+        assert!(query.len() > MAX_LEN);
+        assert!(NameOrDescription::try_from(query).is_ok());
+    }
+
+    // The length bound must hold for serde-based extractors too, not only for
+    // the explicit `TryFrom` constructor.
+    #[test]
+    fn deserialization_enforces_the_limit() {
+        let ok =
+            serde_json::from_value::<NameOrDescription>(serde_json::json!("a".repeat(MAX_LEN)));
+        assert!(ok.is_ok());
+
+        let too_long =
+            serde_json::from_value::<NameOrDescription>(serde_json::json!("a".repeat(MAX_LEN + 1)));
+        assert!(too_long.is_err());
     }
 }

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -270,6 +270,14 @@ impl Database {
         cache: bool,
     ) -> DbResult<Vec<CrateOverview>> {
         /// Adds a `where` clause for case-insensitive matching of name and description.
+        ///
+        /// Case folding is only reliable for ASCII. The pattern is lowercased by
+        /// Rust, which is Unicode-aware, while the columns are lowercased by the
+        /// database: PostgreSQL folds according to the locale, but SQLite ships
+        /// without ICU and folds ASCII only. A description containing "ÄPFEL"
+        /// therefore stays uppercase on SQLite and never matches the lowercased
+        /// pattern, for any spelling of the query. Crate names are unaffected,
+        /// since `OriginalName` restricts them to ASCII.
         fn add_filter_by_name_and_description<T: Iden + Copy, N: Iden, D: Iden>(
             query: &mut SelectStatement,
             table: T,

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -273,11 +273,11 @@ impl Database {
         ///
         /// Case folding is only reliable for ASCII. The pattern is lowercased by
         /// Rust, which is Unicode-aware, while the columns are lowercased by the
-        /// database: PostgreSQL folds according to the locale, but SQLite ships
-        /// without ICU and folds ASCII only. A description containing "ÄPFEL"
-        /// therefore stays uppercase on SQLite and never matches the lowercased
-        /// pattern, for any spelling of the query. Crate names are unaffected,
-        /// since `OriginalName` restricts them to ASCII.
+        /// database: `PostgreSQL` folds according to the locale, but `SQLite`
+        /// ships without ICU and folds ASCII only. A description containing
+        /// "ÄPFEL" therefore stays uppercase on `SQLite` and never matches the
+        /// lowercased pattern, for any spelling of the query. Crate names are
+        /// unaffected, since `OriginalName` restricts them to ASCII.
         fn add_filter_by_name_and_description<T: Iden + Copy, N: Iden, D: Iden>(
             query: &mut SelectStatement,
             table: T,

--- a/crates/registry/src/cratesio_api.rs
+++ b/crates/registry/src/cratesio_api.rs
@@ -54,7 +54,7 @@ pub async fn search(
     let url = Url::parse_with_params(
         settings.proxy.api.as_str(),
         &[
-            ("q", params.q.0.as_str()),
+            ("q", params.q.as_str()),
             ("per_page", &params.per_page.0.to_string()),
         ],
     )

--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -559,7 +559,7 @@ pub async fn list_crate_versions(
 )]
 pub async fn search(State(db): DbState, params: SearchParams) -> ApiResult<Json<SearchResult>> {
     let crates = db
-        .search_in_crate_name_and_description(&params.q.0, false)
+        .search_in_crate_name_and_description(params.q.as_str(), false)
         .await?
         .into_iter()
         .map(|c| Crate {

--- a/crates/web-ui/src/ui.rs
+++ b/crates/web-ui/src/ui.rs
@@ -1482,7 +1482,7 @@ mod tests {
             settings,
         )
         .oneshot(
-            Request::get(&format!("/search?name={}", "a".repeat(65)))
+            Request::get(format!("/search?name={}", "a".repeat(65)))
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/web-ui/src/ui.rs
+++ b/crates/web-ui/src/ui.rs
@@ -273,9 +273,8 @@ pub struct SearchParams {
     )
 )]
 pub async fn search(Query(params): Query<SearchParams>, State(db): DbState) -> Json<Pagination> {
-    let name: String = params.name.into();
     let crates = db
-        .search_in_crate_name_and_description(&name, params.cache.unwrap_or(false))
+        .search_in_crate_name_and_description(params.name.as_str(), params.cache.unwrap_or(false))
         .await
         .unwrap_or_default();
     Json(Pagination {
@@ -1468,6 +1467,55 @@ mod tests {
         assert_eq!(0, result_crates.crates.len());
         assert_eq!(0, result_crates.page);
         assert_eq!(0, result_crates.page_size);
+    }
+
+    // The length bound lives on `NameOrDescription`. It has to hold here too,
+    // where the value arrives through serde rather than an explicit `TryFrom`.
+    #[tokio::test]
+    async fn search_rejects_overlong_query() {
+        let mock_db = MockDb::new();
+        let (settings, storage) = test_deps();
+
+        let r = app(
+            mock_db,
+            KellnrCrateStorage::new(&settings, storage),
+            settings,
+        )
+        .oneshot(
+            Request::get(&format!("/search?name={}", "a".repeat(65)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(StatusCode::BAD_REQUEST, r.status());
+    }
+
+    #[tokio::test]
+    async fn search_accepts_multi_word_query() {
+        let mut mock_db = MockDb::new();
+        let (settings, storage) = test_deps();
+
+        mock_db
+            .expect_search_in_crate_name_and_description()
+            .with(eq("vcard parser"), eq(false))
+            .returning(|_, _| Ok(vec![]));
+
+        let r = app(
+            mock_db,
+            KellnrCrateStorage::new(&settings, storage),
+            settings,
+        )
+        .oneshot(
+            Request::get("/search?name=vcard%20parser")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(StatusCode::OK, r.status());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #1358.

## The length bound only applied to one of the two entry points

`NameOrDescription` derived `Deserialize` without `#[serde(try_from = "String")]`, so the derived newtype deserializer never consulted `TryFrom`. Only `search_params.rs`, which calls `TryFrom` explicitly, applied the bound. The web UI receives the value through `Query<SearchParams>`, so it accepted a query of any length:

| Endpoint | 64 chars | 65 chars | 5000 chars |
|---|---|---|---|
| `/api/v1/crates?q=` | 200 | 400 | 400 |
| `/search?name=` (before) | 200 | **200** | **200** |

`OriginalName` carries that attribute already, with a comment describing this exact hazard. Adding it to `NameOrDescription` closes the gap.

The inner field is now private so the invariant cannot be sidestepped, with `as_str`, `into_inner` and `Deref` in its place. That lets `cratesio_api.rs`, `kellnr_api.rs` and `ui.rs` stop reaching through `params.q.0`.

The bound also counted bytes rather than characters, so a query of umlauts was rejected at roughly half the advertised 64 characters. It now counts characters, and the error message names the limit.

## Case folding is ASCII only

Documented on `add_filter_by_name_and_description`: the pattern is folded by Rust, which is Unicode-aware, while the columns are folded by the database. PostgreSQL folds by locale, SQLite ships without ICU and folds ASCII only, so a description containing "ÄPFEL" stays uppercase on SQLite and never matches the lowercased pattern for any spelling of the query. Crate names are unaffected, since `OriginalName` restricts them to ASCII. Left as a documented limitation rather than a code change.

## Tests

Two on the web UI path, the one that was broken:

```
search_rejects_overlong_query   ... ok    (65 chars -> 400)
search_accepts_multi_word_query ... ok    ("vcard parser" -> 200)
```

Plus five unit tests on `NameOrDescription`, covering the 64/65 boundary through both `TryFrom` and serde, and the character-vs-byte count.

Mutation-checked: removing `#[serde(try_from = "String")]` makes `search_rejects_overlong_query` fail, and it fails by reaching the mock's `unimplemented!()`, meaning the oversized request travelled all the way to the database call. The test is not vacuous.

## Verification

- `just test`: 399 passed, 78 skipped (was 392)
- `just clippy`: clean
- `cargo fmt --check`: clean
- `sqlite_` and `postgres_` search tests both still pass
