### PR TITLE
feat(api): implement pagination for search

### DIFF
--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -1392,9 +1392,12 @@ impl DbProvider for Database {
     async fn search_in_crate_name_and_description(
         &self,
         contains: &str,
+        limit: u64,
+        offset: u64,
         cache: bool,
     ) -> DbResult<Vec<CrateOverview>> {
-        self.query_crates(Some(contains), None, cache).await
+        self.query_crates(Some(contains), Some((limit, offset)), cache)
+            .await
     }
 
     async fn get_crate_overview_list(

--- a/crates/db/src/provider.rs
+++ b/crates/db/src/provider.rs
@@ -221,6 +221,8 @@ pub trait DbProvider: Send + Sync {
     async fn search_in_crate_name_and_description(
         &self,
         contains: &str,
+        limit: u64,
+        offset: u64,
         cache: bool,
     ) -> DbResult<Vec<CrateOverview>>;
     async fn get_crate_overview_list(
@@ -645,7 +647,7 @@ pub mod mock {
                 unimplemented!()
             }
 
-            async fn search_in_crate_name_and_description(&self, contains: &str, cache: bool) -> DbResult<Vec<CrateOverview>> {
+            async fn search_in_crate_name_and_description(&self, contains: &str, limit: u64, offset: u64, cache: bool) -> DbResult<Vec<CrateOverview>> {
                 unimplemented!()
             }
 

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -1483,7 +1483,7 @@ async fn search_in_crate_name_and_description_found_match(test_db: &kellnr_db::D
     )
     .await
     .unwrap();
-    let expected = vec![
+    let page_1 = vec![
         CrateOverview {
             name: "crate".to_string(),
             version: "2.2.0".to_string(),
@@ -1498,6 +1498,9 @@ async fn search_in_crate_name_and_description_found_match(test_db: &kellnr_db::D
             total_downloads: 10,
             ..CrateOverview::default()
         },
+    ];
+
+    let page_2 = vec![
         CrateOverview {
             name: "foo_crate".to_string(),
             version: "2.0.0".to_string(),
@@ -1516,8 +1519,24 @@ async fn search_in_crate_name_and_description_found_match(test_db: &kellnr_db::D
         },
     ];
 
+    let expected: Vec<_> = page_1.iter().chain(page_2.iter()).cloned().collect();
+
+    let results_1 = test_db
+        .search_in_crate_name_and_description("crate", 2, 0, false)
+        .await
+        .unwrap();
+
+    assert_eq!(page_1, results_1);
+
+    let results_2 = test_db
+        .search_in_crate_name_and_description("crate", 2, 2, false)
+        .await
+        .unwrap();
+
+    assert_eq!(page_2, results_2);
+
     let search_results = test_db
-        .search_in_crate_name_and_description("crate", false)
+        .search_in_crate_name_and_description("crate", 100, 0, false)
         .await
         .unwrap();
 

--- a/crates/registry/src/kellnr_api.rs
+++ b/crates/registry/src/kellnr_api.rs
@@ -550,6 +550,7 @@ pub async fn list_crate_versions(
     tag = "crates",
     params(
         ("q" = String, Query, description = "Search query"),
+        ("page" = Option<u32>, Query, description = "Page to return"),
         ("per_page" = Option<u32>, Query, description = "Results per page")
     ),
     responses(
@@ -558,10 +559,13 @@ pub async fn list_crate_versions(
     security(("cargo_token" = []))
 )]
 pub async fn search(State(db): DbState, params: SearchParams) -> ApiResult<Json<SearchResult>> {
+    let limit = params.per_page.0;
+    let offset = (params.page.0 - 1) * limit;
     let crates = db
-        .search_in_crate_name_and_description(params.q.as_str(), false)
+        .search_in_crate_name_and_description(params.q.as_str(), limit as u64, offset as u64, false)
         .await?
         .into_iter()
+        .take(params.per_page.0)
         .map(|c| Crate {
             name: c.name,
             max_version: c.version,
@@ -569,7 +573,6 @@ pub async fn search(State(db): DbState, params: SearchParams) -> ApiResult<Json<
                 .description
                 .unwrap_or_else(|| "No description set".to_string()),
         })
-        .take(params.per_page.0)
         .collect::<Vec<Crate>>();
 
     Ok(Json(SearchResult {
@@ -1810,8 +1813,8 @@ mod reg_api_tests {
         let mut mock_db = MockDb::new();
         mock_db
             .expect_search_in_crate_name_and_description()
-            .with(eq("foo"), eq(false))
-            .returning(|_, _| Ok(vec![]));
+            .with(eq("foo"), eq(10), eq(0), eq(false))
+            .returning(|_, _, _, _| Ok(vec![]));
 
         let kellnr = app_search(Arc::new(mock_db));
         let r = kellnr
@@ -1828,12 +1831,34 @@ mod reg_api_tests {
     }
 
     #[tokio::test]
+    async fn search_verify_page() {
+        let mut mock_db = MockDb::new();
+        mock_db
+            .expect_search_in_crate_name_and_description()
+            .with(eq("foo"), eq(20), eq(40), eq(false))
+            .returning(|_, _, _, _| Ok(vec![]));
+
+        let kellnr = app_search(Arc::new(mock_db));
+        let r = kellnr
+            .oneshot(
+                Request::get("/api/v1/crates?q=foo&page=3&per_page=20")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let result_msg = r.into_body().collect().await.unwrap().to_bytes();
+        assert!(serde_json::from_slice::<SearchResult>(&result_msg).is_ok());
+    }
+
+    #[tokio::test]
     async fn search_verify_per_page() {
         let mut mock_db = MockDb::new();
         mock_db
             .expect_search_in_crate_name_and_description()
-            .with(eq("foo"), eq(false))
-            .returning(|_, _| Ok(vec![]));
+            .with(eq("foo"), eq(20), eq(0), eq(false))
+            .returning(|_, _, _, _| Ok(vec![]));
 
         let kellnr = app_search(Arc::new(mock_db));
         let r = kellnr
@@ -1847,6 +1872,25 @@ mod reg_api_tests {
 
         let result_msg = r.into_body().collect().await.unwrap().to_bytes();
         assert!(serde_json::from_slice::<SearchResult>(&result_msg).is_ok());
+    }
+
+    #[tokio::test]
+    async fn search_verify_page_out_of_range() {
+        let settings = get_settings();
+        let kellnr = TestKellnr::fake(settings).await;
+        let r = kellnr
+            .client
+            .clone()
+            .oneshot(
+                Request::get("/api/v1/crates?q=foo&page=0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let result_msg = r.into_body().collect().await.unwrap().to_bytes();
+        assert!(serde_json::from_slice::<SearchResult>(&result_msg).is_err());
     }
 
     #[tokio::test]

--- a/crates/registry/src/search_params.rs
+++ b/crates/registry/src/search_params.rs
@@ -9,7 +9,28 @@ use kellnr_common::name_or_description::NameOrDescription;
 
 pub struct SearchParams {
     pub q: NameOrDescription,
+    pub page: Page,
     pub per_page: PerPage,
+}
+
+pub struct Page(pub usize);
+
+impl TryFrom<usize> for Page {
+    type Error = &'static str;
+
+    fn try_from(page: usize) -> Result<Self, Self::Error> {
+        if page < 1 {
+            Err("page has to be at least 1.")
+        } else {
+            Ok(Self(page))
+        }
+    }
+}
+
+impl From<Page> for usize {
+    fn from(pp: Page) -> Self {
+        pp.0
+    }
 }
 
 pub struct PerPage(pub usize);
@@ -57,6 +78,18 @@ where
         let q =
             NameOrDescription::try_from(q).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
+        let page = query_params
+            .get("page")
+            .unwrap_or(&"1".to_string())
+            .parse::<usize>()
+            .map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid value for page: {e}"),
+                )
+            })?;
+        let page = Page::try_from(page).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
         let per_page = query_params
             .get("per_page")
             .unwrap_or(&"10".to_string())
@@ -70,7 +103,7 @@ where
         let per_page =
             PerPage::try_from(per_page).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
-        Ok(Self { q, per_page })
+        Ok(Self { q, page, per_page })
     }
 }
 

--- a/crates/web-ui/src/ui.rs
+++ b/crates/web-ui/src/ui.rs
@@ -274,7 +274,12 @@ pub struct SearchParams {
 )]
 pub async fn search(Query(params): Query<SearchParams>, State(db): DbState) -> Json<Pagination> {
     let crates = db
-        .search_in_crate_name_and_description(params.name.as_str(), params.cache.unwrap_or(false))
+        .search_in_crate_name_and_description(
+            params.name.as_str(),
+            100,
+            0,
+            params.cache.unwrap_or(false),
+        )
         .await
         .unwrap_or_default();
     Json(Pagination {
@@ -1443,8 +1448,8 @@ mod tests {
 
         mock_db
             .expect_search_in_crate_name_and_description()
-            .with(eq("doesnotexist"), eq(false))
-            .returning(move |_name, _| Ok(vec![]));
+            .with(eq("doesnotexist"), eq(100), eq(0), eq(false))
+            .returning(move |_name, _, _, _| Ok(vec![]));
 
         let r = app(
             mock_db,
@@ -1499,8 +1504,8 @@ mod tests {
 
         mock_db
             .expect_search_in_crate_name_and_description()
-            .with(eq("vcard parser"), eq(false))
-            .returning(|_, _| Ok(vec![]));
+            .with(eq("vcard parser"), eq(100), eq(0), eq(false))
+            .returning(|_, _, _, _| Ok(vec![]));
 
         let r = app(
             mock_db,
@@ -1534,8 +1539,8 @@ mod tests {
         let tc = test_crate_summary.clone();
         mock_db
             .expect_search_in_crate_name_and_description()
-            .with(eq("hello"), eq(false))
-            .returning(move |_, _| Ok(vec![tc.clone()]));
+            .with(eq("hello"), eq(100), eq(0), eq(false))
+            .returning(move |_, _, _, _| Ok(vec![tc.clone()]));
 
         let r = app(
             mock_db,


### PR DESCRIPTION
This PR adds support for `page=` query argument when using the Registry Web API.

This implements a subset of the behavior of `page=` as seen in crates.io:

https://github.com/rust-lang/crates.io/blob/main/src/controllers/helpers/pagination.rs

Like crates.io, we add support for `page=` arguments, with 1-based counting. Pages are calculated based on the `per_page=` argument (i.e. with `page` and `per_page` we can determine `limit` and `offset`).

Unlike crates.io, we do not implement `seek`, since Kellnr results do not produce `seek` URLs.

For the `web-ui` API, in this PR we keep the same behavior we have previously; the `/search` endpoint does not implement pagination (it uses `offset = 0` and `limit = 100`).